### PR TITLE
[autopilot] skills: add building-python-mcp-servers skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,17 @@
         "./skills/community",
         "./skills/library-review",
         "./skills/git-hygiene",
-        "./skills/web-app-architecture"
+        "./skills/web-app-architecture",
+        "./skills/mcp-servers"
+      ]
+    },
+    {
+      "name": "python-mcp-servers",
+      "description": "Build robust Python MCP servers - tool error contracts, subprocess wrapping, single-file vs packaged distribution, and global-state-free testing",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/mcp-servers"
       ]
     },
     {

--- a/skills/mcp-servers/SKILL.md
+++ b/skills/mcp-servers/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: building-python-mcp-servers
+description: Builds robust Python MCP (Model Context Protocol) servers with FastMCP — tool design, error contracts, subprocess/CLI wrapping, single-file vs packaged distribution, global-state-free testing, and prompt-injection awareness. Use when writing an MCP server, exposing a tool or CLI to an LLM client, debugging tool registration/packaging, or testing MCP tools.
+---
+
+# Building Python MCP Servers
+
+MCP servers expose tools to an LLM client (Claude Desktop, Claude Code, etc.).
+The LLM is the caller, so the failure modes differ from a normal library: errors
+must be machine-readable, every input is untrusted, and a green test suite often
+proves nothing about whether the tools actually work. This skill encodes the
+patterns that recur when these go wrong.
+
+## Quick Start (FastMCP)
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("my-server")
+
+@mcp.tool()
+def read_config(path: str) -> dict:
+    """Read a config file. `path` must be absolute."""
+    p = Path(path)
+    if not p.is_absolute():
+        return {"error": "path must be absolute"}
+    if not p.exists():
+        return {"error": f"no such file: {path}"}
+    return {"data": p.read_text()}
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+## Error Contract: return, don't raise — and stay consistent
+
+An uncaught exception surfaces to the LLM as an opaque protocol error it can't
+reason about. Return a structured result with a predictable shape instead, and
+make callers check for it.
+
+- **Pick one error shape and use it everywhere.** A dict with an `"error"` key is
+  the common convention. Document that callers must check for it.
+- **Batch tools must report skips, not swallow them.** The most common
+  inconsistency: a single-item tool collects per-item errors, but a sibling
+  "do this across a directory" tool silently `continue`s past files that fail to
+  load. For automation that is invisible data loss. Every batch tool should
+  return both results and a per-item `skipped`/`errors` list.
+
+```python
+@mcp.tool()
+def validate_dir(path: str) -> dict:
+    results, skipped = {}, []
+    for f in Path(path).glob("*.md"):
+        try:
+            results[f.name] = _validate(f)
+        except Exception as e:
+            skipped.append({"file": f.name, "error": str(e)})  # never silently continue
+    return {"results": results, "skipped": skipped}
+```
+
+> Type footgun: YAML auto-parses an unquoted ISO date (`date: 2025-06-15`) into a
+> `datetime.date`, **not** a `str` or `datetime.datetime`. A validator that
+> handles only `str`/`datetime` will false-positive on native YAML dates. When
+> validating parsed values, enumerate every type the parser can actually produce.
+
+## Wrapping a subprocess / CLI
+
+A huge share of MCP servers shell out to another tool. Three failures recur:
+
+**1. Don't discard stdout on a non-zero exit.** Many CLIs exit non-zero *by
+design* (a linter/mutation-tester reporting findings) and write their real
+output to **stdout** with an empty stderr. A wrapper that returns
+`f"Error: {result.stderr}"` whenever `returncode != 0` reports a successful run
+to the LLM as an empty `"Error: "`.
+
+```python
+def run_tool(args: list[str]) -> dict:
+    r = subprocess.run(args, capture_output=True, text=True)
+    return {                       # hand BOTH streams to the model; let it judge
+        "returncode": r.returncode,
+        "stdout": r.stdout,
+        "stderr": r.stderr,
+    }
+```
+
+**2. Pin to the version you actually wrap, and verify subcommands exist.** A
+server written against a tool's 2.x CLI while the project pins 3.x will call
+subcommands and flags that no longer exist — every wrapped tool breaks at
+runtime. Check the *installed* version's `--help`, not your memory of it.
+
+**3. Parse args safely.** Splitting an extra-args string with `str.split()`
+breaks quoted, space-containing arguments — use `shlex.split()`. Never
+interpolate a client-supplied string into a shell command; pass an argv list to
+`subprocess.run` (no `shell=True`). When a tool accepts a target/path, remember
+the LLM (or content it read) chose it — validate it.
+
+## No module-level global state (it makes the server untestable)
+
+Parsing CLI args at import time and stashing them in module globals
+(`WORKING_DIR`, `MAKEFILE_PATH`, caches…) forces every test to
+`del sys.modules["server"]` and re-import under a patched `sys.argv` just to
+reset state — brittle and easy to get wrong. Keep configuration in an object or
+pass it through; construct tools from a factory.
+
+```python
+def build_server(config: Config) -> FastMCP:
+    mcp = FastMCP("my-server")
+
+    @mcp.tool()
+    def do_thing(x: str) -> dict:
+        return {"result": _work(x, config)}   # config captured, not global
+
+    return mcp
+```
+
+This also avoids **double registration**: a module-level "create all tools" loop
+*plus* the same loop inside `main()` registers every tool twice when the file is
+run directly (`uv run server.py`, as Claude Desktop does) versus via a console
+entry point. Register in exactly one place.
+
+## Distribution: single-file vs packaged
+
+MCP servers are often launched as a single file (`uv run server.py`), so two
+packaging traps are easy to ship without noticing:
+
+- **Module/package name collision.** Having both a top-level `server.py` *and* a
+  `server/` package directory means `import server` resolves to the package
+  (shadowing the module), so a console entry point like `server:main` finds no
+  `main` and fails. Only running the file directly works. Pick one name.
+- **Over-narrow build includes.** A build config like
+  `only-include = ["server.py"]` produces a wheel containing just that file —
+  `import server.analyzers` raises `ModuleNotFoundError` for anyone who
+  `pip install`s it, even though `uv run server.py` works locally. If you ship a
+  package, include the package and its data files.
+
+For a PEP 723 single-file server, pin explicit versions in the inline
+`# /// script` header **and** keep them in sync with `pyproject.toml`; a
+transitive-only dependency (imported but never declared) breaks the moment the
+intermediary drops it.
+
+## Testing: prove the tools actually work
+
+Mocking the subprocess/transport layer and asserting that argv contains certain
+tokens locks in commands that may not exist in the wrapped tool — the suite stays
+green while every tool is broken at runtime. A passing CI here does **not** mean
+the server works.
+
+- Keep at least one **integration test that invokes the real wrapped tool** (or
+  a real sample file) end to end.
+- A bare `import server` smoke test is meaningless under a name collision (it can
+  import an empty package). Assert a tool *runs and returns expected output*.
+- Test the error contract: malformed input returns your `"error"` shape, batch
+  tools populate `skipped`.
+
+## Treat all tool I/O as untrusted (prompt injection)
+
+Tool inputs, file contents, and especially **other tools' descriptions** can be
+attacker-influenced and flow into the model's context. A server that feeds such
+text back into a second LLM call is itself a prompt-injection surface — its
+output is advisory, not authoritative. Don't grant a tool more filesystem/network
+reach than it needs, validate paths, and never let tool output be treated as a
+trusted instruction.
+
+## MCP Server Checklist
+
+```
+Contract:
+- [ ] One consistent error shape; documented that callers check it
+- [ ] Batch tools return a per-item skipped/errors list (never silent continue)
+- [ ] Inputs validated (absolute paths, allowed types) before use
+
+Subprocess:
+- [ ] Both stdout and stderr returned; non-zero exit not assumed to be failure
+- [ ] Pinned to the wrapped tool's actual version; subcommands verified
+- [ ] shlex.split for arg strings; argv list (no shell=True)
+
+Structure:
+- [ ] No module-level CLI parsing / global state
+- [ ] Tools registered in exactly one place
+
+Distribution & tests:
+- [ ] No server.py / server/ name collision; build includes the whole package
+- [ ] PEP 723 header deps pinned and synced with pyproject
+- [ ] An integration test exercises a real tool (not just mocked argv)
+```
+
+## Learn More
+
+This skill is based on the [Guide to Developing High-Quality Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) by [Will McGinnis](https://mcginniscommawill.com/).


### PR DESCRIPTION
## What changed
Adds a new skill, `skills/mcp-servers/SKILL.md` (`building-python-mcp-servers`), and registers it in `.claude-plugin/marketplace.json` — added to the `python-library-complete` bundle and given a dedicated `python-mcp-servers` bundle so it installs.

## Why — the cross-repo pattern
MCP (Model Context Protocol) servers are a domain the library didn't cover, yet the same handful of mistakes show up again and again across LLM-facing tool servers. The skill encodes those recurring failure modes in fully generic terms:

- **Error contract** — return a consistent structured error (`{"error": ...}`) instead of raising; batch/directory tools must report a per-item `skipped`/`errors` list rather than silently `continue`-ing past files that fail to load (invisible data loss for automation). Plus the YAML-date type footgun where a validator only handling `str`/`datetime` false-positives on a native `datetime.date`.
- **Subprocess wrapping** — don't discard stdout when the wrapped tool exits non-zero *by design* and writes its real output to stdout (returning `"Error: " + stderr` reports success as an empty error); pin to and verify the wrapped CLI's actual version; use `shlex.split` and an argv list (no `shell=True`).
- **No module-level global state** — import-time CLI parsing into globals forces `del sys.modules`/re-import gymnastics in tests; build from a factory. This also prevents double tool registration between a module-level loop and `main()`.
- **Distribution traps** — `server.py` module vs `server/` package name collisions that break console entry points, and over-narrow build includes that ship a wheel missing the package; keep PEP 723 inline deps pinned and synced.
- **Testing** — mock-only suites that assert argv tokens stay green while every tool is broken; keep at least one real integration test.
- **Prompt-injection awareness** — treat all tool I/O (especially other tools' descriptions) as untrusted.

## How a reader benefits
Anyone building or reviewing a Python MCP server gets an opinionated checklist and copy-pasteable patterns that head off the exact runtime breakages, false-green test suites, and broken pip distributions that these servers commonly ship with.