### PR TITLE
[autopilot] skills: code-quality — flag falsy-guard and is-literal anti-patterns

### DIFF
--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -84,6 +84,32 @@ except ValueError as e:
     logger.error(e)
 ```
 
+```python
+# Bad: truthiness guard swallows a legitimate 0 / 0.0 / "" / False
+hour = config.get("start_hour") or 9   # a valid 0 (midnight) silently becomes 9
+if self.max_drawdown:                  # max_drawdown=0 silently disables the limit
+    enforce(self.max_drawdown)
+
+# Good: guard on None, not on truthiness
+hour = config.get("start_hour")
+hour = 9 if hour is None else hour
+if self.max_drawdown is not None:
+    enforce(self.max_drawdown)
+```
+
+`x = x or default` is fine only when the single falsy value you mean to replace
+is an empty container (e.g. `items = items or []`). For numeric, boolean, or
+string fields where `0`, `False`, or `""` are meaningful inputs, it is a bug —
+use `x if x is not None else default`.
+
+```python
+# Bad: identity comparison against a literal (ruff flags this as F632)
+if name is not "":   # CPython interning makes it *sometimes* work — never rely on it
+
+# Good: value comparison
+if name != "":
+```
+
 ## Pythonic Idioms
 
 ```python
@@ -122,6 +148,8 @@ Code Quality:
 - [ ] Public API has docstrings
 - [ ] No mutable default arguments
 - [ ] Specific exception handling
+- [ ] Truthiness guards don't swallow valid 0/False/"" (guard on `is None`)
+- [ ] No `is`/`is not` against literals (use ==/!=)
 - [ ] py.typed marker present
 ```
 


### PR DESCRIPTION
## What changed
Adds two closely-related correctness anti-patterns to `skills/code-quality/SKILL.md` under **Common Anti-Patterns**, plus matching checklist items:

1. **Truthiness guards that swallow a legitimate `0` / `0.0` / `""` / `False`.** A `value or default` fallback or an `if value:` guard treats a meaningful zero/empty/false input as "unset" — e.g. a valid `0` (midnight) hour silently becomes the default, or passing `0` for a limit silently disables it. The fix is to guard on `is None`. Notes the one safe case (`items = items or []` for empty containers).
2. **`is`/`is not` against a string/number literal** (ruff F632) — relies on CPython interning and is unreliable; use `==`/`!=`.

## Why — the cross-repo pattern
These two footguns recur across multiple projects: numeric `or`-fallbacks replacing a legitimate `0`, an `if limit:` guard that quietly turns a safety limit off when the limit is `0`, and an identity check used in place of an empty-string comparison. They share a root cause — conflating "falsy" with "absent" — and both are statically detectable (the second is a ruff lint), which fits this skill's tooling focus.

## How a reader benefits
The skill's existing example (`items = items or []`) is the *safe* case; readers now get the explicit contrast showing when that idiom is a bug and the `is None` form to reach for, heading off a class of silent correctness defects that pass tests because the zero/empty path is rarely exercised.