### PR TITLE
Accept explicit version as positional arg in bump_version.py

### DIFF
--- a/skills/release-management/scripts/bump_version.py
+++ b/skills/release-management/scripts/bump_version.py
@@ -153,8 +153,8 @@ def main():
     )
     parser.add_argument(
         "bump_type",
-        choices=["major", "minor", "patch"],
         nargs="?",
+        metavar="major|minor|patch|X.Y.Z",
         help="Type of version bump (or specific version like 1.2.3)",
     )
     parser.add_argument(


### PR DESCRIPTION
Closes #3

## What changed
`skills/release-management/scripts/bump_version.py` documented `python bump_version.py 1.5.0` (set an explicit version), but the `bump_type` positional was declared with `choices=["major", "minor", "patch"]`, so argparse rejected anything else before the supporting logic ran.

This drops the `choices=[...]` restriction and adds a `metavar` so `--help` still shows the accepted forms. Validation is unchanged — `bump_version()` already raises a clear `ValueError` for unknown tokens, and `--version` is untouched.

## Verification
Ran the script against a temp `pyproject.toml` (`version = "1.2.3"`) with system `python3`:

- `patch` → `1.2.3 -> 1.2.4`; `minor` → `1.3.0`; `major` → `2.0.0`
- `1.5.0` (positional) → `1.2.3 -> 1.5.0`, file written as `version = "1.5.0"` (no "invalid choice" error)
- `wat` → `Error: Unknown bump type: wat`, exit code 1
- `--version 1.5.0` → `1.2.3 -> 1.5.0` (unchanged)