### PR TITLE
[autopilot] skills: project-setup — keep local checks identical to CI

### DIFF
--- a/skills/project-setup/CI.md
+++ b/skills/project-setup/CI.md
@@ -34,18 +34,26 @@ jobs:
         run: uv pip install --system -e ".[dev]"
 
       - name: Lint
-        run: ruff check src tests
+        run: |
+          ruff check src tests
+          ruff format --check src tests   # formatting is a separate gate from ruff check
 
       - name: Type check
         run: mypy src
 
       - name: Test
-        run: pytest --cov-report=xml
-
-      - name: Upload coverage
-        if: matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v3
+        run: pytest --cov=src --cov-report=term-missing
 ```
+
+Run the **same** `ruff check` + `ruff format --check` commands here that `make
+lint` runs — if they diverge, a branch that passes locally goes red in CI (or
+vice versa). Lint the same paths, too (add `examples/`/`docs/` if they hold
+Python).
+
+Coverage is reported in the job log via `--cov-report=term-missing` rather than
+uploaded to a third-party service — no external account, token, or network
+dependency in the gate. If you later want an XML/HTML artifact, add
+`--cov-report=xml` and store it as a build artifact instead of uploading it.
 
 ## Pre-commit Configuration
 

--- a/skills/project-setup/MAKEFILE.md
+++ b/skills/project-setup/MAKEFILE.md
@@ -15,8 +15,12 @@ dev:
 test:
 	pytest
 
+# lint must stay read-only and mirror CI exactly — no --fix here (that belongs in
+# `format`). An auto-fixing lint target mutates files and exits 0, hiding real
+# violations that CI's read-only check then fails on.
 lint:
 	ruff check src tests
+	ruff format --check src tests   # formatting is NOT covered by ruff check
 
 format:
 	ruff format src tests

--- a/skills/project-setup/SKILL.md
+++ b/skills/project-setup/SKILL.md
@@ -67,6 +67,39 @@ pytest                      # Test
 mypy src                    # Type check
 ```
 
+## Keep local checks identical to CI
+
+The most common CI failure is not a bug — it's a check that passes locally but
+fails in CI (or vice versa) because the two run different commands. Two rules
+prevent an entire class of "green locally, red in CI" (and chronically-red base
+branch) problems:
+
+**1. `make lint` must be read-only — never `--fix`.** A `lint` target that runs
+`ruff check --fix` mutates your files and almost always exits 0, so pre-existing
+violations silently sit on the branch while CI's read-only `ruff check` goes red.
+Put `--fix` only in `format` and the pre-commit hook. `make lint` should run the
+*exact* commands CI runs.
+
+**2. CI (and `make lint`) must check formatting too.** `ruff check` and
+`ruff format` are different tools: the linter passing says nothing about
+formatting. Gate on both, or formatting drift ships / turns a branch red
+unexpectedly:
+
+```bash
+ruff check src tests          # lint rules
+ruff format --check src tests # formatting — REQUIRED, not implied by ruff check
+```
+
+Lint the **same paths** in the Makefile and CI (add `examples/`, `docs/`, etc. if
+they contain Python) — a narrower local scope lets violations accumulate in dirs
+CI checks. Configure ruff under `[tool.ruff.lint]` (not the deprecated top-level
+`select`/`ignore`), and keep `requires-python` and `[tool.ruff] target-version`
+in sync so ruff doesn't apply upgrade rules for a version you don't support.
+
+For coverage, prefer running `pytest --cov` with a terminal report
+(`--cov-report=term-missing`) in the CI log over uploading to a third-party
+service — no external account, token, or network dependency in the gate.
+
 ## Key Decisions
 
 | Choice | Recommendation | Why |
@@ -83,7 +116,8 @@ mypy src                    # Type check
 Project Setup:
 - [ ] src/ layout with py.typed marker
 - [ ] pyproject.toml (not setup.py)
-- [ ] Makefile with dev/test/lint/format
+- [ ] Makefile with dev/test/lint/format (lint read-only, no --fix)
+- [ ] `make lint` runs the exact `ruff check` + `ruff format --check` CI runs
 - [ ] .pre-commit-config.yaml
 - [ ] .github/workflows/ci.yml
 - [ ] README.md, LICENSE, CHANGELOG.md


### PR DESCRIPTION
## What changed

Sharpens the **setting-up-python-libraries** skill so its Makefile/CI templates match how a well-run repo actually gates, closing a recurring "green locally, red in CI" gap.

- **SKILL.md** — new *"Keep local checks identical to CI"* section: `make lint` must be read-only (never `--fix`), CI and lint must gate on `ruff format --check` (a separate tool from `ruff check`), lint the same paths in both places, use `[tool.ruff.lint]` and keep `requires-python`/`target-version` in sync, and prefer a `--cov-report=term-missing` log over uploading to a third-party coverage service. Checklist updated to match.
- **MAKEFILE.md** — `lint` target now also runs `ruff format --check` and carries a comment warning that an auto-fixing lint target silently hides violations.
- **CI.md** — Lint step runs both `ruff check` and `ruff format --check`; the Codecov upload step is replaced with an in-log `--cov=src --cov-report=term-missing`.

## Pattern that motivated it

Across repos two failure modes kept recurring: (1) a `make lint` that runs `ruff check --fix` mutates files and exits 0, so pre-existing violations sit unnoticed until CI's plain `ruff check` goes red — sometimes leaving the base branch chronically red; and (2) CI that runs only the linter, never the formatter, so formatting drift ships or turns a locally-green branch red. A standing preference to avoid third-party coverage-upload services (rely on the pytest-cov terminal report) also contradicted the template's Codecov step.

## Benefit

A reader who follows the templates gets `make lint` that mirrors CI exactly, gates on formatting as well as lint rules, and reports coverage without an external dependency — eliminating the most common class of CI surprises before they happen.