### PR TITLE
[autopilot] skills: testing — treat deprecation warnings as errors to catch dependency drift

### DIFF
--- a/skills/testing-strategy/SKILL.md
+++ b/skills/testing-strategy/SKILL.md
@@ -158,6 +158,51 @@ network call fails loudly instead of "passing."
 it pass documents the bug as acceptable. Assert the *correct* behavior and let it
 fail until the bug is fixed (use `xfail(strict=True)` to track it without red CI).
 
+## Catch Deprecation Drift Before It Breaks You
+
+A dependency deprecates an API in one release and removes it in the next. Code
+that calls the deprecated form keeps working — emitting a `DeprecationWarning` or
+`FutureWarning` nobody reads — right up until a routine `pip install -U` upgrades
+past the removal and the call becomes a hard `AttributeError`/`TypeError`. By
+then the break is a production incident, not a warning.
+
+This is the same failure mode across every ecosystem: `DataFrame.append` (removed
+in pandas 2.0), `matplotlib.cm.get_cmap` (removed in 3.9), a networkx layout
+helper renamed out of the top-level namespace, `datetime.utcnow()` (deprecated in
+3.12, hundreds of warnings buried in the log). In each case the signal existed as
+a warning for a full release cycle and was ignored.
+
+Turn that warning into a test failure so it fails loud while it's still just a
+deprecation:
+
+```toml
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",                                    # any warning fails the test
+    # Targeted, documented escape hatches for warnings you can't fix yet:
+    "ignore:.*legacy config.*:DeprecationWarning:some_dependency",
+]
+```
+
+`"error"` promotes every warning to an exception, so a `DeprecationWarning` from a
+dependency (or from your own soon-to-break call) turns a green suite red the day
+the warning first appears — months before the removal lands. Add a *narrow,
+commented* `ignore` entry (scoped by message and module) for third-party warnings
+you genuinely can't act on yet; never blanket-ignore a whole category, or you
+re-bury the signal you just surfaced.
+
+Two habits make this land:
+
+- **Don't pin ancient dependencies and forget them.** A lockfile frozen on a
+  years-old release hides every deprecation the ecosystem has issued since. Test
+  against a current resolution (e.g. a periodic unpinned CI job) so drift shows up
+  as a failing warning, not a surprise years later.
+- **When you wrap an external CLI or library, verify its *installed* API, not the
+  one you remember.** Code written against a tool's 2.x commands while the project
+  pins 3.x fails only at runtime — and unit tests that mock the subprocess pass
+  green while asserting flags that no longer exist. Check the real version's
+  surface (`--help`, `inspect`, the changelog) before asserting against it.
+
 ## Checklist
 
 ```
@@ -167,6 +212,7 @@ Testing:
 - [ ] No external service dependencies (mock them)
 - [ ] Coverage > 85%
 - [ ] Tests run in CI
+- [ ] filterwarnings = ["error"] so deprecations fail loud (with narrow, commented ignores only)
 ```
 
 ## Learn More


### PR DESCRIPTION
## What changed

Adds a **"Catch Deprecation Drift Before It Breaks You"** section to the `testing-python-libraries` skill, plus a checklist item.

The core technique: set `filterwarnings = ["error"]` in `[tool.pytest.ini_options]` so a `DeprecationWarning`/`FutureWarning` from a dependency (or your own soon-to-break call) turns the suite red the day it first appears — months before the API is removed and the call becomes a hard `AttributeError`/`TypeError`. Guidance includes narrow, commented `ignore` escape hatches (never blanket-ignore), plus two supporting habits: don't freeze on ancient pins, and verify a wrapped tool's *installed* API rather than the version you remember.

## Motivating pattern

Across many libraries the same failure recurs: code calls an API that a dependency deprecated a release ago and has since removed — e.g. `DataFrame.append` (gone in pandas 2.0), `matplotlib.cm.get_cmap` (gone in 3.9), a networkx layout helper moved out of the top-level namespace, or `datetime.utcnow()` (deprecated in 3.12, warnings buried in the log). In every case the deprecation warning existed for a full release cycle and was ignored, so a routine dependency upgrade turned a silent warning into a breakage. A related variant: a tool wrapper coded against a dependency's *old* CLI while pinning a newer major, with mocked tests staying green against flags that no longer exist.

## How a reader benefits

The existing skill already covers false-green *assertion* quality; this adds the complementary preventive: making dependency-deprecation drift fail loud in CI while it's still cheap to fix, so libraries don't silently rot against a moving ecosystem.