### PR TITLE
[autopilot] skills: prevent empty-evaluator false-greens

### DIFF
--- a/skills/python/testing-strategy/SKILL.md
+++ b/skills/python/testing-strategy/SKILL.md
@@ -154,6 +154,31 @@ network call fails loudly instead of "passing."
 - Marker filters (`-m "not integration"`) can deselect the only meaningful tests.
   Reproduce CI's exact marker expression locally before trusting green.
 
+**Empty evaluator sets must not mean "all clear."** Auditors, policy engines,
+and validation pipelines often compute a score from the enabled rules. A category
+filter can accidentally disable every rule; if the scoring code maps
+`results == []` to `score = 100`, an unsupported request becomes a silent perfect
+pass. Treat an empty post-filter rule set as a configuration/error state, or keep
+an aggregate rule enabled when it is the evaluator for every category.
+
+```python
+enabled = [rule for rule in rules if rule.supports(requested_categories)]
+if not enabled:
+    raise NoApplicableRulesError(requested_categories)
+results = evaluate(enabled, subject)
+```
+
+Regression tests must assert more than the final score: request each supported
+category (and representative combinations), assert that at least one rule ran,
+and use a known failing subject so a no-op path cannot look clean.
+
+```python
+result = audit(known_noncompliant_subject, categories=["bias"])
+assert result.rules_evaluated > 0
+assert result.issues                 # proves filtering did not bypass evaluation
+assert result.overall_score < 100
+```
+
 **Tests written around a bug.** Wrapping a call in `try/except RuinError` to make
 it pass documents the bug as acceptable. Assert the *correct* behavior and let it
 fail until the bug is fixed (use `xfail(strict=True)` to track it without red CI).


### PR DESCRIPTION
## What changed

Sharpened the Python testing skill with a guardrail for audit, policy, and validation pipelines: filtering must never remove every evaluator and then convert an empty result into a perfect score. Added a concrete fail-closed implementation pattern and regression assertions that prove at least one rule ran against a known failing subject.

## Motivation

A recurring false-green pattern appears when category filtering leaves no applicable checks, while downstream scoring treats an empty result as success. The resulting clean report is indistinguishable from a genuine pass even though nothing was evaluated.

## Reader benefit

Readers now have a compact review rule and test recipe that catches silent no-op evaluation paths before they ship.