### PR TITLE
[autopilot] skills: protect FastAPI OpenAPI routes

### DIFF
--- a/skills/python/web-app-architecture/AUTH.md
+++ b/skills/python/web-app-architecture/AUTH.md
@@ -78,6 +78,30 @@ protection on state-changing requests: a per-session token rendered into forms a
 checked on POST with `hmac.compare_digest`. Token-in-header schemes (bearer) are not
 CSRF-exposed and don't need this.
 
+## Protecting FastAPI's OpenAPI schema
+
+Setting `docs_url=None` and `redoc_url=None` hides the interactive UIs, but
+FastAPI still registers `/openapi.json` whenever `openapi_url` is non-`None`.
+That built-in route is registered before later decorators, so adding a guarded
+`@app.get("/openapi.json")` without disabling the built-in route leaves the schema
+public: the built-in handler shadows the guarded one.
+
+Disable automatic registration, then serve the schema yourself:
+
+```python
+app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+@app.get("/openapi.json", include_in_schema=False)
+async def private_openapi(_: AdminDep) -> dict:
+    return app.openapi()
+```
+
+Schema generation still works when `openapi_url=None`; only the automatic route
+is disabled. Add regression tests proving an anonymous request receives `401` or
+`403`, an authorized request receives `200`, and the response contains `"openapi"`.
+Inspect `app.routes` if duplicate paths are suspected—a passing authorized test
+alone will not reveal that an earlier public handler won routing precedence.
+
 ## Quick guide
 
 | App type                         | Scheme            |

--- a/skills/python/web-app-architecture/SKILL.md
+++ b/skills/python/web-app-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-python-web-apps
-description: Provides an opinionated reference architecture for production Python web apps — FastAPI + async SQLAlchemy + Postgres, pydantic-settings config, Stripe billing, server-rendered Jinja or a decoupled SPA, deployed as a single Docker image on a managed platform via Terraform. Use when starting a new SaaS/web app, choosing a stack, structuring routers/services/models, wiring Stripe webhooks, setting up config/secrets, or deciding how to deploy.
+description: Provides an opinionated reference architecture for production Python web apps — FastAPI + async SQLAlchemy + Postgres, pydantic-settings config, Stripe billing, server-rendered Jinja or a decoupled SPA, deployed as a single Docker image on a managed platform via Terraform. Use when starting a new SaaS/web app, choosing a stack, structuring routers/services/models, wiring Stripe webhooks, protecting FastAPI docs or OpenAPI routes, setting up config/secrets, or deciding how to deploy.
 ---
 
 # Building Python Web Apps
@@ -150,6 +150,7 @@ Config:
 Billing & security:
 - [ ] Exactly one Stripe webhook, signature-verified, idempotent
 - [ ] Passwords bcrypt-hashed; auth via reusable dependencies
+- [ ] Private OpenAPI schema served only by a custom guarded route (`openapi_url=None`)
 - [ ] Sentry + PostHog init guarded (no-op when unkeyed, never break a request)
 
 Ship:


### PR DESCRIPTION
Adds a focused FastAPI authentication pattern for protecting the generated OpenAPI schema.

The motivating pattern is that hiding Swagger and ReDoc does not disable the framework-generated schema endpoint, and a later guarded route can be shadowed by the built-in route registered first. The skill now shows how to disable automatic schema routing, expose a dependency-guarded replacement, and test both anonymous and authorized access.

Readers benefit from a concrete configuration and regression-test checklist that prevents an apparently protected API schema from remaining public.