### PR TITLE
[autopilot] skills: scope dependency audits to the target project

### DIFF
--- a/skills/python/security-audit/SKILL.md
+++ b/skills/python/security-audit/SKILL.md
@@ -13,7 +13,7 @@ uv run python scripts/security_scan.py .
 
 # Or individually:
 uvx bandit -r src/ -ll                       # High-severity static analysis
-uvx pip-audit                                # Dependency vulnerabilities
+uvx pip-audit .                              # This project's dependencies
 uvx semgrep --config auto src/               # Pattern-based SAST
 uvx detect-secrets scan > .secrets.baseline  # Secrets detection
 ```

--- a/skills/python/security-audit/scripts/security_scan.py
+++ b/skills/python/security-audit/scripts/security_scan.py
@@ -80,10 +80,10 @@ def run_bandit(project_path: Path) -> ScanResult:
     return ScanResult("bandit", True, findings, blocking)
 
 
-def run_pip_audit() -> ScanResult:
-    """Run pip-audit for dependency vulnerabilities. Blocks on any vulnerable package."""
+def run_pip_audit(project_path: Path) -> ScanResult:
+    """Audit the target project's dependencies. Blocks on any vulnerable package."""
     stdout, err = _run(
-        ["pip-audit", "--format", "json"],
+        ["pip-audit", "--format", "json", str(project_path)],
         "pip-audit",
         "uv tool install pip-audit",
     )
@@ -221,7 +221,7 @@ def main():
 
     scanners = [
         ("bandit", lambda: run_bandit(project_path)),
-        ("pip-audit", run_pip_audit),
+        ("pip-audit", lambda: run_pip_audit(project_path)),
         ("semgrep", lambda: run_semgrep(project_path)),
         ("secrets", lambda: check_secrets(project_path)),
     ]


### PR DESCRIPTION
## What changed

- Pass the requested project path to pip-audit in the security scan wrapper.
- Update the standalone command example to audit the current project explicitly.

## Motivation

Dependency scanners invoked without an input can inspect the scanner's active environment instead of the project the operator asked to scan. That mismatch can produce a clean report for the wrong dependency set. Project-scoped invocation makes the wrapper's dependency results match its path argument and the other scanners' scope.

## Reader benefit

Readers can run the documented aggregate or standalone security scan against another checkout and trust that dependency findings belong to that target project.