### PR TITLE
Reject invalid project scaffolder inputs

### DIFF
--- a/skills/python/project-setup/scripts/create_project.py
+++ b/skills/python/project-setup/scripts/create_project.py
@@ -7,10 +7,27 @@ Usage:
 """
 
 import argparse
+import json
+import keyword
+import re
 import sys
 from datetime import date, datetime
 from pathlib import Path
 from textwrap import dedent
+
+
+def _package_name(distribution_name: str) -> str:
+    package_name = re.sub(r"[-_.]+", "_", distribution_name).lower()
+    if not package_name.isidentifier() or keyword.iskeyword(package_name):
+        raise ValueError(
+            f"Project name {distribution_name!r} does not produce a valid Python "
+            f"package name ({package_name!r})"
+        )
+    return package_name
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
 
 
 def create_project(
@@ -20,8 +37,7 @@ def create_project(
     description: str = "A Python library",
 ) -> Path:
     """Create a new Python library project structure."""
-    # Convert name to valid Python package name
-    package_name = name.replace("-", "_").lower()
+    package_name = _package_name(name)
     project_dir = Path(name)
 
     if project_dir.exists():
@@ -45,14 +61,14 @@ def create_project(
         build-backend = "setuptools.build_meta"
 
         [project]
-        name = "{name}"
+        name = {_toml_string(name)}
         version = "0.1.0"
-        description = "{description}"
+        description = {_toml_string(description)}
         readme = "README.md"
         requires-python = ">=3.10"
         license = {{text = "MIT"}}
         authors = [
-            {{name = "{author}", email = "{email}"}}
+            {{name = {_toml_string(author)}, email = {_toml_string(email)}}}
         ]
         classifiers = [
             "Development Status :: 3 - Alpha",
@@ -76,8 +92,8 @@ def create_project(
         ]
 
         [project.urls]
-        Homepage = "https://github.com/username/{name}"
-        Repository = "https://github.com/username/{name}"
+        Homepage = {_toml_string(f"https://github.com/username/{name}")}
+        Repository = {_toml_string(f"https://github.com/username/{name}")}
 
         [tool.setuptools.packages.find]
         where = ["src"]
@@ -107,7 +123,7 @@ def create_project(
 
     # Create __init__.py
     init_py = dedent(f'''
-        """{description}."""
+        {f"{description}."!r}
 
         __version__ = "0.1.0"
     ''').strip()

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -1,0 +1,85 @@
+import importlib
+import importlib.util
+import os
+import py_compile
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "skills"
+    / "python"
+    / "project-setup"
+    / "scripts"
+    / "create_project.py"
+)
+SPEC = importlib.util.spec_from_file_location("create_project", SCRIPT)
+assert SPEC and SPEC.loader
+CREATE_PROJECT = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CREATE_PROJECT
+SPEC.loader.exec_module(CREATE_PROJECT)
+
+
+class CreateProjectTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.previous_cwd = Path.cwd()
+        os.chdir(self.temp_dir.name)
+
+    def tearDown(self):
+        os.chdir(self.previous_cwd)
+        self.temp_dir.cleanup()
+
+    def test_dotted_distribution_name_uses_importable_package_name(self):
+        project = CREATE_PROJECT.create_project("my.project")
+
+        self.assertTrue((project / "src" / "my_project" / "__init__.py").is_file())
+        self.assertTrue((project / "tests" / "test_my_project.py").is_file())
+        sys.path.insert(0, str(project / "src"))
+        try:
+            package = importlib.import_module("my_project")
+            self.assertEqual(package.__version__, "0.1.0")
+        finally:
+            sys.path.pop(0)
+            sys.modules.pop("my_project", None)
+
+    def test_invalid_package_name_fails_before_creating_directory(self):
+        for name in ("123-library", "has!punctuation", "class"):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "valid Python package name"):
+                    CREATE_PROJECT.create_project(name)
+                self.assertFalse(Path(name).exists())
+
+    def test_metadata_is_serialized_in_toml_and_python(self):
+        author = 'O"Connor\\Tools'
+        email = 'dev\\ops"team@example.com'
+        description = 'A "quoted" \\library'
+
+        project = CREATE_PROJECT.create_project(
+            "quoted-library",
+            author=author,
+            email=email,
+            description=description,
+        )
+
+        with (project / "pyproject.toml").open("rb") as file:
+            metadata = tomllib.load(file)["project"]
+        self.assertEqual(metadata["description"], description)
+        self.assertEqual(metadata["authors"], [{"name": author, "email": email}])
+
+        for python_file in project.rglob("*.py"):
+            py_compile.compile(python_file, doraise=True)
+
+    def test_hyphenated_name_keeps_existing_layout(self):
+        project = CREATE_PROJECT.create_project("my-library")
+
+        self.assertTrue((project / "src" / "my_library").is_dir())
+        self.assertTrue((project / "tests" / "test_my_library.py").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #28

## Summary

- normalize standard distribution-name separators to underscores for import package and test module names
- reject normalized names that are not valid, non-keyword Python identifiers before creating directories
- serialize generated TOML values and Python module documentation safely
- add temporary-directory coverage for dotted names, invalid identifiers, quoted/backslashed metadata, generated Python compilation, and existing hyphenated-name behavior

## Verification

- `uv run python -m unittest discover -s tests -v` — 4 tests passed
- `uv run python -m compileall -q skills tests` — passed
- `git diff --check` — passed