### PR TITLE
[autopilot] skills: assert the whole set, not mere presence

### DIFF
--- a/skills/python/testing-strategy/SKILL.md
+++ b/skills/python/testing-strategy/SKILL.md
@@ -125,6 +125,28 @@ assert result.returncode == 0 or "html_static_path" in result.stderr  # masks re
 assert "ui" in todo.tags                                              # also matches "build"
 ```
 
+**Presence assertions are blind to duplicates.** `assert X in output` proves that
+*at least one* X exists. It cannot tell you that there are two, or which one a
+consumer will honor. That is the exact shape of bugs in generated output — HTML
+tags, config keys, emitted headers — where a framework's base template and your
+override each emit one and they disagree. Extract every occurrence and compare
+the whole list.
+
+```python
+# BAD — passes with one correct tag, and equally with two conflicting ones.
+assert '<link rel="canonical"' in html
+
+# GOOD — pins both the count and the values.
+canonicals = re.findall(r'<link rel="canonical" href="([^"]*)"', html)
+assert canonicals == ["https://example.com/guide/"]
+```
+
+When two emitters produce the "same" tag they often don't format it identically
+(one self-closing, one not), so anchor the pattern on the attribute you care
+about and stop before the tag close — otherwise the duplicate you're hunting
+slips past your regex and the test looks clean. The same rule applies to anything
+countable: assert `len(rows) == 2` and the row values, not `assert rows`.
+
 **Mocking the thing under test.** If you patch `_run_command` and only assert the
 argv tokens, the test locks in a command that may not exist — it stays green even
 after the subcommands or flags it builds are renamed or removed upstream. Mock at


### PR DESCRIPTION
## What changed

Adds one anti-pattern to the **Tests That Lie: Avoiding False-Green** section of `skills/python/testing-strategy/SKILL.md`: *presence assertions are blind to duplicates*, with the extract-and-compare-the-whole-list fix.

## The pattern that motivated it

A recurring failure mode when testing **generated output** (rendered HTML, config files, emitted headers): a framework's base template emits a tag, your override emits it too, and the two disagree. The document is broken — consumers get two conflicting answers — but `assert '<link rel="canonical"' in html` passes happily, because it only ever proved that *at least one* occurrence exists.

The bug and the test's blind spot are the same shape, so the test can never fail on it. The fix is to `re.findall` every occurrence and compare the whole list to the expected values, which pins both the count and the content.

A second, subtler trap is included: two emitters rarely format the "same" tag identically (one self-closing, one not), so a regex anchored on the tag close silently misses the duplicate it was written to catch. Anchor on the attribute and stop before the close.

## How a reader benefits

This generalizes past HTML to anything countable — `assert rows` becomes `assert len(rows) == 2` plus the values. It gives a concrete, copyable rule for a class of test that looks thorough, reads as green, and cannot detect the duplicate-output bug it appears to cover.

Verified the example behaves as documented: the presence assertion returns `True` on a two-conflicting-canonical document while the `findall` comparison correctly fails it, and the regex matches across both tag formats.