### PR TITLE
[autopilot] skills: warn on spoofable client-IP behind a proxy

### DIFF
--- a/skills/python/web-app-architecture/DEPLOYMENT.md
+++ b/skills/python/web-app-architecture/DEPLOYMENT.md
@@ -43,6 +43,52 @@ CMD ["uv", "run", "uvicorn", "myapp.main:app", "--host", "0.0.0.0", "--port", "8
 `--proxy-headers --forwarded-allow-ips '*'` makes the app trust the platform's
 load-balancer headers (correct scheme/host for secure cookies and redirects).
 
+### The client-IP trap this opens up
+
+Trusting `X-Forwarded-For` (XFF) for scheme/host is fine. Trusting it to identify
+*who* a request is from is a footgun, and it's the same mistake in three places:
+**rate-limit keys, IP allowlists, and the IP you write to audit logs**. A proxy
+*appends* the real peer to the XFF chain, so the **left-most** value is whatever the
+client sent — attacker-controlled. slowapi's `get_remote_address` returns
+`request.client.host`, which under `--forwarded-allow-ips '*'` is *also* derived from
+that same untrusted header. So a naive limiter keyed on the left-most XFF (or on
+`request.client.host` with a wildcard trust) buckets by a value the attacker picks:
+
+```python
+# WRONG — attacker rotates X-Forwarded-For per request, lands in a fresh bucket
+# every time. Measured effect: ~0/50 login attempts blocked vs 45/50 on the real IP.
+client_ip = request.headers["x-forwarded-for"].split(",")[0].strip()
+limiter = Limiter(key_func=get_remote_address)  # request.client.host, same problem
+```
+
+The trustworthy value is a **fixed position counted from the right** — you trust
+exactly as many hops as you actually run. With one managed load balancer in front,
+that's the last entry:
+
+```python
+# RIGHT — trust N proxies (here 1); take the (N+1)th from the right.
+TRUSTED_PROXY_HOPS = 1
+
+def real_client_ip(request: Request) -> str:
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        chain = [p.strip() for p in xff.split(",") if p.strip()]
+        if len(chain) > TRUSTED_PROXY_HOPS:
+            return chain[-(TRUSTED_PROXY_HOPS + 1)]
+    return request.client.host
+
+limiter = Limiter(key_func=real_client_ip)
+```
+
+Define this **once** and reuse it everywhere an IP is consumed — the bug reappears
+per-copy when `_get_client_ip` is reimplemented in the limiter, the auth router, and
+the audit service independently. Nothing else guards brute force by default
+(a `failed_attempts` column with no lockout enforcement does not), so a spoofable
+limiter is the whole defense. Note too that an in-memory limiter is **per process**,
+so effective limits multiply by instance count — back anything that must hold
+app-wide (login, password-reset, registration) with a shared store (Redis), not
+process memory.
+
 ## One image, three roles
 
 | Role    | Command                                            |

--- a/skills/python/web-app-architecture/SKILL.md
+++ b/skills/python/web-app-architecture/SKILL.md
@@ -150,6 +150,8 @@ Config:
 Billing & security:
 - [ ] Exactly one Stripe webhook, signature-verified, idempotent
 - [ ] Passwords bcrypt-hashed; auth via reusable dependencies
+- [ ] Client IP for rate-limit keys/allowlists/audit logs taken from a fixed
+      position in the X-Forwarded-For chain (not the spoofable left-most value)
 - [ ] Private OpenAPI schema served only by a custom guarded route (`openapi_url=None`)
 - [ ] Sentry + PostHog init guarded (no-op when unkeyed, never break a request)
 


### PR DESCRIPTION
## What changed

Sharpened the `building-python-web-apps` skill (`web-app-architecture`) with a new **client-IP trap** subsection in DEPLOYMENT.md and a matching review-checklist line in SKILL.md.

The skill already recommends running uvicorn with `--proxy-headers --forwarded-allow-ips '*'` (correct for scheme/host), but said nothing about the security hole that configuration opens. The new material explains:

- Behind a proxy that **appends** the real peer, the **left-most** `X-Forwarded-For` value is attacker-controlled — and `slowapi`'s `get_remote_address` / `request.client.host` under a wildcard trust is derived from that same header.
- A rate limiter keyed on that value is a total bypass: rotate XFF per request → fresh bucket every time → login/reset/registration limits do nothing.
- The fix: derive the client IP from a **fixed position counted from the right** (trust exactly the number of proxy hops you run), defined **once** and reused for rate-limit keys, IP allowlists, and audit-log IPs — the bug reappears each time `_get_client_ip` is reimplemented per module.
- In-memory limiters are per-process (limits multiply by instance count), so app-wide limits need a shared store.

## Motivating pattern (generic)

Across several FastAPI apps deployed behind a managed load balancer, the same class of bug recurred: client IP taken from the left-most XFF entry (or from `request.client.host` under `--forwarded-allow-ips '*'`), making rate limiting spoofable and audit-log source IPs forgeable — often duplicated across three separate call sites in one app.

## How a reader benefits

Anyone following this skill's deployment recipe gets the caveat and a copy-pasteable `real_client_ip` helper right next to the `--forwarded-allow-ips` line that creates the exposure, instead of shipping a rate limiter that silently does nothing.