### PR TITLE
[autopilot] skills: sharpen web-app CSRF guidance (token-rendered != enforced; state-changing GETs)

### DIFF
--- a/skills/python/web-app-architecture/AUTH.md
+++ b/skills/python/web-app-architecture/AUTH.md
@@ -78,6 +78,25 @@ protection on state-changing requests: a per-session token rendered into forms a
 checked on POST with `hmac.compare_digest`. Token-in-header schemes (bearer) are not
 CSRF-exposed and don't need this.
 
+**Rendering a token is not enforcing one.** The frequent failure is per-form
+opt-in: CSRF is only checked where a handler explicitly validates the token (a
+`validate_on_submit()` / an equivalent dependency), so dropping a hidden token
+field into a template does nothing on its own. Any handler that reads the raw
+request body directly — a file-upload endpoint reading uploaded files, an admin
+POST reading raw form fields — stays wide open, and the template's token is
+decorative. Enforce CSRF **globally** (a single middleware/extension that rejects
+any unsafe-method request lacking a valid token), then carve out exceptions
+deliberately, rather than remembering to add the check on every new route. Audit
+by grepping for handlers that read request bodies but never touch the token.
+
+**A state-changing GET can't be CSRF-protected at all.** If a GET request mutates
+state — deactivating an account, confirming an unsubscribe, deleting a row behind a
+plain `<a href>` — no token scheme saves you: the browser will fire it from an
+`<img src>` on any page, and link prefetchers and email scanners trigger it with no
+user action. A client-side `confirm()` dialog is not protection; the attacker's
+request never sees it. Mutations must use POST/DELETE (so CSRF enforcement and
+same-site cookie rules apply); reserve GET for reads.
+
 ## Protecting FastAPI's OpenAPI schema
 
 Setting `docs_url=None` and `redoc_url=None` hides the interactive UIs, but

--- a/skills/python/web-app-architecture/SKILL.md
+++ b/skills/python/web-app-architecture/SKILL.md
@@ -150,6 +150,8 @@ Config:
 Billing & security:
 - [ ] Exactly one Stripe webhook, signature-verified, idempotent
 - [ ] Passwords bcrypt-hashed; auth via reusable dependencies
+- [ ] CSRF enforced globally for cookie auth (not per-form opt-in); no
+      state-changing GET requests — mutations use POST/DELETE
 - [ ] Client IP for rate-limit keys/allowlists/audit logs taken from a fixed
       position in the X-Forwarded-For chain (not the spoofable left-most value)
 - [ ] Private OpenAPI schema served only by a custom guarded route (`openapi_url=None`)


### PR DESCRIPTION
## What changed

Sharpens the **CSRF (cookie-based auth only)** section of `skills/python/web-app-architecture/AUTH.md` with two failure modes, plus a matching review-checklist item in the skill's main file.

## The pattern that motivated it

Across multiple cookie-authed web apps I've seen the same two CSRF gaps recur:

1. **A rendered CSRF token is not an enforced one.** When CSRF is opt-in per form (only checked where a handler explicitly validates the token), dropping a hidden token field into a template does nothing on its own. Any handler that reads the raw request body directly — a file-upload endpoint, an admin POST reading raw form fields — stays wide open while *looking* protected. The fix is to enforce CSRF globally and carve out exceptions deliberately.

2. **A state-changing GET can't be CSRF-protected at all.** A GET that mutates state (deactivate account, confirm unsubscribe, delete behind a plain `<a href>`) is fired by `<img src>`, link prefetchers, and email scanners with no user action, and a client-side `confirm()` is no defense. Mutations must be POST/DELETE.

## How a reader benefits

The prior section correctly said "a per-session token rendered into forms and checked on POST" but didn't warn that *rendering ≠ checking* or that GET mutations bypass CSRF entirely — the exact two ways teams ship a CSRF story that doesn't hold. Now the skill names both, tells the reader to enforce globally and audit by grepping for handlers that read request bodies but never touch the token, and surfaces it in the review checklist.