### PR TITLE
create_project: emit generated Python files with a trailing newline (fix Ruff W292)

### DIFF
--- a/skills/python/project-setup/scripts/create_project.py
+++ b/skills/python/project-setup/scripts/create_project.py
@@ -128,7 +128,7 @@ def create_project(
         __version__ = "0.1.0"
     ''').strip()
 
-    (project_dir / "src" / package_name / "__init__.py").write_text(init_py)
+    (project_dir / "src" / package_name / "__init__.py").write_text(init_py + "\n")
 
     # Create py.typed marker
     (project_dir / "src" / package_name / "py.typed").write_text("")
@@ -146,7 +146,7 @@ def create_project(
     ''').strip()
 
     (project_dir / "tests" / "__init__.py").write_text("")
-    (project_dir / "tests" / f"test_{package_name}.py").write_text(test_init)
+    (project_dir / "tests" / f"test_{package_name}.py").write_text(test_init + "\n")
 
     # Create README
     readme = dedent(f'''

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -74,6 +74,24 @@ class CreateProjectTests(unittest.TestCase):
         for python_file in project.rglob("*.py"):
             py_compile.compile(python_file, doraise=True)
 
+    def test_generated_python_files_end_with_single_newline(self):
+        project = CREATE_PROJECT.create_project("sample-lib")
+
+        init_py = project / "src" / "sample_lib" / "__init__.py"
+        test_py = project / "tests" / "test_sample_lib.py"
+        for python_file in (init_py, test_py):
+            with self.subTest(python_file=python_file.name):
+                contents = python_file.read_text()
+                self.assertTrue(contents, "generated file should not be empty")
+                self.assertTrue(
+                    contents.endswith("\n"),
+                    "generated Python file must end with a newline (Ruff W292)",
+                )
+                self.assertFalse(
+                    contents.endswith("\n\n"),
+                    "generated Python file must end with exactly one newline",
+                )
+
     def test_hyphenated_name_keeps_existing_layout(self):
         project = CREATE_PROJECT.create_project("my-library")
 


### PR DESCRIPTION
Closes #34

## What changed
`create_project.py` wrote the two generated Python sources — `src/<pkg>/__init__.py` and `tests/test_<pkg>.py` — with `dedent(...).strip()`, dropping the trailing newline. A fresh scaffold (`create_project.py sample-lib` → `uv run ruff check src tests`, the same command the generated `.github/workflows/ci.yml` runs) therefore failed Ruff **W292** on both files, so every untouched scaffold started with a red CI lint step.

- Append `"\n"` to both `write_text(...)` calls so each generated Python file ends with exactly one newline.
- Add a regression test (`test_generated_python_files_end_with_single_newline`) asserting both generated Python sources end with exactly one newline (fails on either a missing or a doubled trailing newline).

Scope kept to scaffold-output correctness: no unrelated templates reformatted, no tool versions changed.

## Verification
- `uv run python -m unittest tests.test_create_project` → **OK** (5 tests).
- Mutation check: reverting the `__init__.py` newline fix makes the new test **FAIL** with the W292 message; restoring it passes. Confirms the test is not vacuous.
- End-to-end on a fresh project: generated `sample-lib`, then `uvx ruff check sample-lib/src sample-lib/tests` → **All checks passed! (exit 0)** without modifying the scaffold. `tail -c` confirms `__init__.py` ends with a single `\x0a`.