### PR TITLE
[autopilot] skills: verify direct-reference dependency builds

### DIFF
--- a/skills/python/packaging/SKILL.md
+++ b/skills/python/packaging/SKILL.md
@@ -85,6 +85,31 @@ from importlib.resources import files
 data = files("my_package.data").joinpath("file.json").read_text()
 ```
 
+## Direct-Reference Dependencies Need a Real Build
+
+A dependency such as `toolkit @ https://example.com/toolkit.whl` may resolve in
+an install dry run without invoking the build backend. With Hatchling, the real
+wheel build then fails unless direct references are explicitly allowed:
+
+```toml
+[project]
+dependencies = [
+    "toolkit @ https://example.com/releases/toolkit.whl",
+]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+```
+
+Do not use `uv pip install --dry-run .` as the packaging check for this case. It
+can report success without building the project. Run `uv build` (or a real
+`uv pip install .`) so the configured backend validates the metadata:
+
+```bash
+uv build
+uvx twine check dist/*
+```
+
 For detailed templates, see:
 - **[../project-setup/PYPROJECT.md](../project-setup/PYPROJECT.md)** - Complete annotated pyproject.toml (canonical)
 - **[CONDA.md](CONDA.md)** - Conda / conda-forge packaging guide
@@ -152,6 +177,7 @@ Before Release:
 - [ ] Version set correctly
 - [ ] twine check passes
 - [ ] `uv run python -m zipfile -l dist/*.whl` shows every subpackage + data file
+- [ ] Direct-reference dependencies pass a real backend build (not only install dry-run)
 - [ ] No module/package name collision (no foo.py AND foo/)
 - [ ] Installed the wheel into a clean venv and imported a real submodule
       symbol from a directory outside the repo (not just the top-level name)


### PR DESCRIPTION
What changed:
- Added focused Hatchling guidance for direct-reference dependencies.
- Documented the required `allow-direct-references` metadata opt-in.
- Added a release checklist item requiring a real backend build.

Motivating pattern:
Dependency resolution and install dry-runs can succeed without invoking the configured build backend, while the actual wheel build rejects direct-reference metadata. This creates a false-green packaging check that fails only at distribution time.

Reader benefit:
Maintainers get the exact configuration and verification commands needed to catch this class of packaging failure before release.