### PR TITLE
[autopilot] skills: make tox interpreter policy explicit

### DIFF
--- a/skills/python/project-setup/CI.md
+++ b/skills/python/project-setup/CI.md
@@ -90,6 +90,33 @@ of upstream release dates, not your diff. These failure modes all recur:
   from "skip" to "hard fail"), reddening an unrelated PR. Pin it, and set the
   behavior explicitly in config rather than relying on the default.
 
+### Tox: make missing-interpreter behavior explicit
+
+A tox envlist does not install those Python versions. If the runner provides only
+Python 3.12 while tox declares `py310,py311,py312`, the result depends on tox's
+missing-interpreter policy — and relying on its current default makes unrelated
+tool upgrades capable of breaking CI.
+
+Choose one owner for the version matrix:
+
+- **GitHub Actions owns it (preferred):** install one matrix Python per job and
+  run only that matching tox environment.
+- **Tox owns it:** install every declared interpreter before invoking tox.
+- **A single-interpreter job intentionally runs what is available:** opt into
+  skipping explicitly so a tox upgrade cannot change the contract.
+
+```ini
+# tox.ini, or legacy_tox_ini in pyproject.toml
+[tox]
+envlist = py310,py311,py312
+skip_missing_interpreters = true
+```
+
+Do not use `skip_missing_interpreters = true` to pretend an uninstalled version
+was tested. The CI log and status checks must still make the actual coverage
+obvious; for a supported-version gate, install every version or use an Actions
+matrix.
+
 Rule of thumb: pin every tool that gates the build (linter, formatter, type
 checker, toolchain, test runner) to an explicit version, and bump them in their
 own dedicated PR — so a tooling bump's fallout lands in a diff that's *about* the


### PR DESCRIPTION
## What changed

- Added concrete guidance for deciding whether GitHub Actions or tox owns the Python-version matrix.
- Documented `skip_missing_interpreters = true` for jobs intentionally running only available interpreters.
- Warned that skipping must not be presented as coverage for versions that were never installed.

## Pattern

A multi-environment tox configuration can declare more Python versions than a CI runner actually installs. When an unpinned tox release changes its missing-interpreter default from skip to failure, an unrelated change can turn CI red; blindly enabling skips can instead produce a false-green compatibility claim. Making both the interpreter owner and missing-interpreter behavior explicit keeps the gate stable and its coverage honest.

## Reader benefit

Readers can choose a reproducible matrix design, avoid tool-default breakage, and ensure CI status checks accurately communicate which Python versions ran.