### PR TITLE
[autopilot] skills: prove a regression test can fail (mutate the fix)

### DIFF
--- a/skills/python/testing-strategy/SKILL.md
+++ b/skills/python/testing-strategy/SKILL.md
@@ -205,6 +205,61 @@ assert result.overall_score < 100
 it pass documents the bug as acceptable. Assert the *correct* behavior and let it
 fail until the bug is fixed (use `xfail(strict=True)` to track it without red CI).
 
+## Prove the Test Can Fail: Mutate the Fix
+
+Every regression test makes an implicit claim — *this would have caught the bug*.
+The only way to check the claim is to put the bug back and watch the test go red.
+Do it once, while the fix is still fresh in your head; it takes a minute and it is
+the difference between a regression test and a decoration.
+
+```bash
+# 1. revert the fix (git stash, or hand-edit the guard back to its broken form)
+# 2. run ONLY the new test — it must FAIL, and for the right reason
+uv run pytest tests/test_paths.py::test_symlink_escape_rejected -q
+# 3. restore the fix — it must pass
+```
+
+**Mutate each half of a compound guard separately.** A fix that validates an input
+*and* re-checks the resolved result looks redundant until you revert each half on
+its own.
+
+```python
+def _resolve_baseline(name: str) -> Path:
+    if ".." in name or not NAME_RE.fullmatch(name):   # mutation A
+        raise ValueError(name)
+    path = (BASE_DIR / f"{name}.json").resolve()
+    if not path.is_relative_to(BASE_DIR.resolve()):   # mutation B
+        raise ValueError(name)
+    return path
+```
+
+Reverting A is caught by a `../../etc/passwd` test. Reverting B is caught *only*
+by a symlink placed inside the approved directory that points outside it — a test
+most suites don't have. If reverting one half leaves the suite green, you have a
+test gap, not a redundant check: write the test that pins it.
+
+**Know what "red" looks like for the mutation you chose.** A reintroduced bug does
+not always surface as a clean assertion failure.
+
+- Remove a retry/iteration cap and the suite **hangs** instead of failing. Run the
+  mutated suite under an external timeout — `timeout 60 uv run pytest -q` with no
+  output *is* the reproduction. Making the cap merely unreachable (`> 10**9`) is
+  the honest mutation; the off-by-one (`>` → `>=`) fails loudly and is the cheaper
+  one to re-run day to day.
+- Drop an `await` or a `try` in async code and the runner may die with an unhandled
+  rejection and a worker crash rather than a named test failure. Still red — read
+  the output before concluding your test didn't fire.
+- If the mutated run errors during *collection*, no test ran at all and you have
+  learned nothing about the test.
+
+**A hand-written fixture is itself a mutation — of reality.** When the same person
+authors both a parser and every fixture it is tested against, both encode the same
+assumption, and the suite is green against a guard that cannot fire in production.
+A regex requiring single spaces between tokens matches hand-typed single-space
+fixtures forever, while the live document renders those tokens across indented
+lines. Capture at least one fixture from the real source, commit it, and point the
+guard's test at that.
+
 ## Ambient State: Tests That Only Pass on Your Machine
 
 A test that reads state it never set — environment variables, a module-level
@@ -285,6 +340,7 @@ Testing:
 - [ ] Tests exist for public API
 - [ ] Edge cases covered (empty, boundary, error)
 - [ ] No external service dependencies (mock them)
+- [ ] Each regression test verified red against the reverted fix
 - [ ] No ambient state read unpinned (env vars, module globals, CWD, clock)
 - [ ] Coverage > 85%
 - [ ] Tests run in CI


### PR DESCRIPTION
## What changed

One new section in `skills/python/testing-strategy/SKILL.md` — **"Prove the Test Can Fail: Mutate the Fix"** — plus one checklist line. No other skill touched; no new skill, so no marketplace change.

## The pattern that motivated it

The skill already carries a strong catalog of *shapes* of lying tests ("Tests That Lie: Avoiding False-Green"), but nothing tells the reader the **procedure** for confirming a specific new regression test is actually bound to the fix it ships with. That gap keeps showing up in practice, in a few consistent forms:

- A guard is merged with a test, both are green, and the test would still be green with the guard removed — the fix and the test were never checked against each other.
- A fix has two independently load-bearing halves (validate the input, then re-check the *resolved* result). Reverting one half leaves the suite green, because the test that would catch that half — e.g. a symlink inside an approved directory pointing out of it — was never written. The redundancy looks like belt-and-braces; it is really an untested branch.
- The reintroduced bug doesn't fail loudly. Removing a retry/iteration cap makes the suite **hang** rather than fail, so the mutation has to be run under an external timeout to be observable at all; dropping an `await` in async code kills the runner with an unhandled rejection instead of a named failure. In both cases it is easy to misread the output as "my test didn't fire."
- Every fixture for a parser is hand-authored by the same person who wrote the parser, so both encode the same assumption. The classic version: a regex requiring single spaces between tokens, matched happily by hand-typed fixtures, while the real document renders those tokens across indented lines. Fully green suite, guard that can never fire in production.

## How a reader benefits

They get a concrete three-step loop (revert → run only the new test → restore), a worked example of mutating each half of a compound path-containment guard separately, guidance on recognizing non-obvious "red" (hang / unhandled rejection / collection error) and which mutation is cheap enough to re-run routinely, and the rule that at least one fixture should be captured from the real source rather than typed by hand.