### PR TITLE
[autopilot] skills: job status must be distinct, ordered, and escapable

### DIFF
--- a/skills/python/web-app-architecture/BACKGROUND_JOBS.md
+++ b/skills/python/web-app-architecture/BACKGROUND_JOBS.md
@@ -71,6 +71,55 @@ A `JobStatus` enum (`pending/processing/completed/failed`) and storing the resul
 (or error) on completion is enough — you don't need Celery's full feature set for
 long-poll jobs.
 
+### Status writes: distinct, ordered, and escapable
+
+Status is the only thing the user can see, so three cheap mistakes make a broken run
+look fine — or trap the user in a state they can't leave.
+
+**Failure gets its own terminal value.** An `except` block that writes the success
+sentinel (or writes nothing) reports the failed run as finished, and the user goes
+looking for output that will never exist.
+
+**Write "in progress" before you hand the work off.** Enqueueing first opens a window
+in which a fast-failing worker writes its terminal status *first* and the submitting
+request then overwrites it with `processing` — permanently, since nothing will run
+again to correct it.
+
+```python
+# BAD — the worker may finish before line 2, and failure is indistinguishable
+# from success.
+await queue.enqueue(job)
+await put_status(db, tenant, "processing")   # can clobber a terminal status
+...
+except Exception:
+    await put_status(db, tenant, "ready")    # same sentinel as the success path
+
+# GOOD
+await put_status(db, tenant, "processing")
+await queue.enqueue(job)
+...
+except Exception:
+    await put_status(db, tenant, "error")    # distinct, terminal
+```
+
+**Read an append-only status history by a monotonic key, not a timestamp.** Second-
+resolution timestamps tie routinely — a job that starts and fails inside one second
+writes two rows with identical stamps, and the tie-break is whatever the planner
+feels like returning.
+
+```sql
+-- BAD: same-second rows tie; either row may come back.
+SELECT status FROM job_status WHERE tenant_id = :t ORDER BY created_at DESC LIMIT 1;
+-- GOOD: the serial/identity PK is monotonic and never ties.
+SELECT status FROM job_status WHERE tenant_id = :t ORDER BY id DESC LIMIT 1;
+```
+
+**Gate the retry path on the in-progress value alone**, never on an allowlist of
+terminal ones (`if status == "processing": block` — not `if status != "ready"`).
+Then any unexpected value, including a state you add later, unblocks the user rather
+than trapping them behind a support request. If reaching a terminal state depends on
+a worker that may never run, age stale in-progress rows out on a deadline.
+
 ### Reserve quotas, then compensate failures
 
 If submitting a job consumes a scarce quota, reserve it atomically **before**

--- a/skills/python/web-app-architecture/SKILL.md
+++ b/skills/python/web-app-architecture/SKILL.md
@@ -136,6 +136,8 @@ Structure:
 - [ ] Logic in services/, not in route handlers
 - [ ] External SDKs (Stripe/email/LLM) isolated behind a service module
 - [ ] /health (or /readyz) actually pings the database
+- [ ] Job status: failure writes its own terminal value, "in progress" is written
+      before the work is handed off, and the current value is read by monotonic id
 
 Data:
 - [ ] Async engine is a lazy singleton with pool_pre_ping


### PR DESCRIPTION
## What changed

Adds a **Status writes: distinct, ordered, and escapable** subsection to
`skills/python/web-app-architecture/BACKGROUND_JOBS.md` (right before the existing
quota-compensation section), plus one line in the SKILL.md review checklist.

## The pattern that motivated it

Across async/queued work, three cheap mistakes repeatedly make a job's *observable*
state lie — and they are independent, so fixing one leaves the others live:

1. **An `except` block that writes the success sentinel.** A failed run reports as
   finished and the user goes looking for output that will never exist. Failure needs
   its own terminal value.
2. **"In progress" written *after* the work is handed off.** A fast-failing worker
   writes its terminal status first, and the submitting request then overwrites it
   with `processing` — permanently, because nothing will run again to correct it.
3. **An append-only status history read by `ORDER BY <timestamp> DESC LIMIT 1`.**
   Second-resolution stamps tie routinely (a job that starts and fails inside one
   second writes two identical stamps) and the tie-break is undefined. The serial /
   identity PK is monotonic and never ties.

The compounding consequence is the reason it's worth encoding: when the retry path is
gated on the in-progress value via a *terminal* allowlist (`if status != "ready"`),
any of the three leaves the user stuck behind a manual/admin fix. Gating on the
in-progress value alone (`if status == "processing"`) makes every unexpected
value — including states added later — unblock rather than trap.

## How a reader benefits

The skill already covers reserving and refunding quota around a job. This closes the
adjacent gap: the status the user actually reads. It gives the bad/good ordering
side by side, the SQL for the ordering key, and the gating rule, so these are caught
at design time instead of surfacing as "it said it worked" or a permanently pinned
account.