### PR TITLE
[autopilot] skills: add verifying-external-behavior (probe before you depend on it)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "homepage": "https://github.com/wdm0006/python-skills",
-    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs"]
+    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts"]
   },
   "plugins": [
     {
@@ -45,6 +45,15 @@
       "strict": false,
       "skills": [
         "./skills/common/sync-jobs"
+      ]
+    },
+    {
+      "name": "verifying-external-behavior",
+      "description": "Confirm what a third-party library, remote API, build backend, or scraped document actually does before depending on it - throwaway probes, permissive clients that forward wrong arguments, per-endpoint docs that don't generalize, fakes that encode your assumption, and dry-runs that skip the failing step",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/common/verifying-external-behavior"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ After installation, you can verify the skills are loaded by running:
 |-------|-------------|----------|
 | **rendering-untrusted-content** | Render stored/authored/imported content into HTML without shipping XSS — enumerating autoescape bypasses (`\|safe`, `Markup`, `innerHTML`), sanitizing Markdown output with an allowlist (Markdown preserves raw HTML by design), keeping table-cell `style` so alignment survives, escaping on both the server and the DOM, and sanitization tests that assert on the rendered prose rather than the JSON-LD copy | — |
 | **keeping-git-repos-clean** | Prevent, detect, and remediate committed secrets and dev artifacts — .gitignore, `git rm --cached`, history scrubbing, credential rotation. Bundled into every language's plugin. | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
+| **verifying-external-behavior** | Confirm what a third-party library, remote API, build backend, or scraped document actually does before depending on it — throwaway probes that run in seconds, permissive clients that forward a misspelled selector instead of rejecting it, status codes that differ between the collection and item forms of a resource, summary response shapes that make a "we already have it" fast path always-false, fakes that only prove your code calls the fake, and dry-runs that skip the step that fails | — |
 | **running-resumable-sync-jobs** | Batch/sync jobs that fail honestly — exit codes that report partial failure, checkpoints safe to resume, per-item tolerance vs. fatal abort, unknown-vs-coerced-`0` in aggregated output, bounded per-page retries, dry-runs that mutate in-memory state identically, and compensating reserved quota | — |
 
 ## Plugin Bundles
@@ -164,7 +165,7 @@ After installation, you can verify the skills are loaded by running:
 
 - **python-library-foundations** — project setup, code quality, testing strategy.
 - **python-library-distribution** — packaging, release management, CLI development.
-- **python-library-quality** — security audit, performance, API design, untrusted-content rendering, git hygiene.
+- **python-library-quality** — security audit, performance, API design, untrusted-content rendering, external-behavior verification, git hygiene.
 - **python-web-app** — web-app architecture (FastAPI, async SQLAlchemy, Stripe, Docker/Terraform deployment) + untrusted-content rendering.
 - **python-mcp-servers** — MCP servers (FastMCP tool design, error contracts, packaging, testing, prompt-injection awareness).
 - **python-llm-features** — LLM-backed features (prompt surfaces, structured outputs, context budgeting, model config wiring, accuracy evaluation).
@@ -172,6 +173,7 @@ After installation, you can verify the skills are loaded by running:
 ### Language-agnostic
 
 - **resumable-sync-jobs** — batch/sync jobs, cron tasks, importers, and paginated fetchers (partial-failure exit codes, resumable checkpoints, bounded retries, quota compensation).
+- **verifying-external-behavior** — integrating a dependency, endpoint, or build backend (probe the exact call, inspect outbound parameters, validate fakes against the real service, skip the dry-run shortcut).
 
 Every language bundle includes **keeping-git-repos-clean** — committed-secret and dev-artifact hygiene applies regardless of language.
 

--- a/skills/common/verifying-external-behavior/SKILL.md
+++ b/skills/common/verifying-external-behavior/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: verifying-external-behavior
+description: Confirms what a third-party library, remote API, build backend, or scraped document actually does before writing code that depends on it — throwaway probes that run in seconds, permissive clients that forward wrong arguments instead of rejecting them, per-endpoint docs that don't generalize, response shapes that make a "fast path" always-false, fakes that encode your assumption rather than the service's behavior, and dry-runs that skip the step that fails. Use when integrating a new dependency or endpoint, writing a tolerated-status or error branch, choosing a client argument name, testing against a fake, or reviewing code that asserts an upstream contract.
+---
+
+# Verifying External Behavior
+
+Most integration bugs are not coding errors. They are a belief about someone
+else's system — a status code, a parameter name, a response shape, a build
+backend's scoping rule — that was never checked and turned out to be wrong. The
+code is written correctly against a contract that does not exist.
+
+The fix is not more care. It is a **probe**: a throwaway command that asks the
+real system the exact question, before the code is written. Probes cost seconds.
+The bugs they prevent are silent, ship green, and are found months later.
+
+## Probe the exact call you are about to write
+
+Not a similar call, not the documented example — the same endpoint form, the same
+library version, the same argument spelling.
+
+```bash
+# A library's real defaults / return shapes, with no venv to create or clean up
+uv run --no-project --with somelib python -c "import somelib; print(somelib.Thing())"
+
+# The exact URL, including the collection-vs-item distinction
+curl -s -o /dev/null -w '%{http_code}\n' https://api.example.com/v1/things
+curl -s -o /dev/null -w '%{http_code}\n' https://api.example.com/v1/things/1
+
+# What a build backend actually put in the artifact
+uv build && unzip -l dist/*.whl
+
+# A real service instead of a fake, for one minute
+docker run --rm -p 6390:6379 redis:7-alpine
+```
+
+Two rules make probes worth the minute they cost:
+
+- **Probe before you design around the answer.** A probe that confirms a
+  parameter tweak "should" fix a discrepancy is worth more than the tweak.
+- **Paste the probe command and its output into the PR, comment, or test.** A
+  finding with no reproduction decays into folklore, and the next person re-derives
+  it — or, worse, trusts it after it has gone stale.
+
+## Permissive clients don't reject wrong arguments — they ignore them
+
+This is the highest-severity class, because the failure returns *plausible data*.
+Many HTTP client wrappers forward keyword arguments verbatim into the query
+string without validating them against their own documented parameter list. The
+remote service then drops the unknown parameter and applies its default — often
+"the authenticated user". A misspelled selector (`owner=` for `owner_screen_name=`,
+`id_=` for `id=`) does not raise; it silently returns *someone else's* records.
+
+Never infer "the library would have rejected that" from the library's declared
+parameter list. Read the bytes that leave the process:
+
+```python
+# Probe: intercept the transport and print the outbound request, then stop.
+import requests
+
+sent = {}
+def spy(self, method, url, **kw):
+    sent["url"], sent["params"] = url, kw.get("params")
+    raise RuntimeError("probe: request intercepted")
+
+requests.Session.request = spy
+try:
+    client.favorites(id_=12345)          # the call you were about to ship
+except RuntimeError:
+    pass
+print(sent)      # {'url': '.../favorites/list.json', 'params': {'id_': 12345}}
+```
+
+If the parameter you passed is not in `params` under the name the service
+documents, the call is wrong no matter how healthy the response looks.
+
+Two corollaries:
+
+- **Pass every selector by keyword.** Clients that bind positional arguments in a
+  per-endpoint order will happily accept `get_thing(owner, slug)` and send `slug`
+  as `owner_id`, while a neighbouring method with the same-looking signature is
+  correct by luck.
+- **Check that the parameter exists at all.** Some endpoints have no equivalent of
+  the selector you want. "Forward it under the right name" is not a fix when the
+  right name does not exist — the feature has to be built differently.
+
+## Per-endpoint docs do not generalize across sibling endpoints
+
+A status code documented for the single-item form frequently does not apply to
+the collection form of the same resource. Verified live against a large public
+REST API: `GET /repos/{repo}/issues` on a repository with issues disabled returns
+**200 with an empty array**, while `GET /repos/{repo}/issues/1` returns **410
+Gone**. Code written to "tolerate 410 when issues are disabled" therefore has a
+branch that never fires, and the real path — an empty 200 — falls through to
+whatever the generic handler does.
+
+Probe the exact URL before writing a tolerated-status branch. If you keep a
+defensive branch for a status you could not reproduce, label it as defensive and
+name the path you *did* observe, so the next reader does not mistake it for
+verified behaviour.
+
+```python
+# Observed: issues-disabled repos return 200 with []. The 410 branch is
+# defensive — the item endpoint documents it, the list endpoint never sent it.
+if resp.status_code == 410:
+    return []
+```
+
+## The response *shape* is part of the contract
+
+List endpoints commonly embed a **summary** object — a handful of identity fields —
+rather than the full entity. A "we already have the data" fast path written
+against the full entity is then always false:
+
+```python
+# This check is intended to skip a per-item fetch. Against summary objects that
+# carry only {login, id, avatar_url}, it is False for every item — so the
+# "fallback" enrichment fetch is the common path, and the loop is N+1.
+if all(k in user for k in ("name", "company", "location", "followers")):
+    return user
+return fetch_user(user["login"])       # runs every time
+```
+
+Before optimizing around a response, print one real element and compare its keys
+to what your code reads. The same probe settles range and boundary assumptions
+that otherwise get "handled" defensively forever: if a per-year query provably
+returns exactly that year's days, the dedup pass guarding against adjacent-year
+leakage is dead code, and saying so in the PR is more valuable than the code.
+
+## A fake proves your code calls the fake
+
+Fakes are written by the same person as the code, from the same beliefs, so they
+agree with each other by construction. Stand the real thing up **once** and re-run
+the same assertions against it — a container is a minute, and it is the only thing
+that validates the semantics the fake asserts: TTL and expiry sentinels, whether a
+client factory is awaitable, key eviction, ordering, which exception type a
+failure raises.
+
+Simulate the outage deterministically instead of mocking the error, so the code
+takes the same path production would:
+
+```python
+# A dead port is a real, instant, deterministic connection failure.
+client = redis.asyncio.from_url("redis://localhost:1")
+```
+
+The same reasoning applies to documents you parse. A hand-written fixture encodes
+your reading of the markup; the live page may render the same tokens across
+indented lines, so a regex requiring single spaces matches every fixture and never
+matches production. Capture one real sample, commit it, and point the parser's
+test at it. Prefer a machine-readable attribute (`data-date="2024-01-01"`) over a
+human-readable string when the source offers both — it survives markup and locale
+changes that a prose regex does not. (See **testing-strategy** for the wider
+false-green audit.)
+
+## Dry-runs skip the step that fails
+
+Resolve-only and plan-only modes are not verification of anything the *real* run
+does after resolution. A dependency resolver's `--dry-run` reports success for a
+requirement whose presence makes the actual build hard-fail, because the dry run
+never builds. A build script's `--check` may never invoke the platform-specific
+tool that breaks.
+
+Run the real operation once, on the platform that matters:
+
+```bash
+uv pip install --dry-run .    # resolves; does NOT build → misses build-time errors
+uv build                      # actually builds → catches them
+```
+
+More generally: if a mode exists specifically to be cheap, ask which step it
+bought that discount by skipping, and whether your bug lives there.
+
+## Some verified behaviour is not yours to fix
+
+A probe sometimes proves the upstream system is simply wrong, or surprising, for
+your use case. Resist reaching for a configuration knob to make the number look
+right — if the underlying model or endpoint produces that output across parameter
+settings, tuning a parameter buries the finding instead of recording it. Write
+down what was observed, at which version, with the command, and choose a different
+approach.
+
+Record findings with three things or they will not survive: **the command**, **the
+observed output**, and **the date**. External behaviour changes; an undated claim
+cannot be re-checked.
+
+## Checklist
+
+```
+Before shipping code that depends on an external system:
+- [ ] The exact call/endpoint/version was probed, not a similar one
+- [ ] Outbound request parameters inspected — names match what the service documents
+- [ ] Selectors passed by keyword, never positionally
+- [ ] Collection and item forms probed separately for status-code branches
+- [ ] One real response element printed and compared against the fields the code reads
+- [ ] Fakes validated against the real service at least once
+- [ ] Failure paths exercised against a real failure (dead port, revoked token), not a mock
+- [ ] Verified with the real build/install, not a dry-run
+- [ ] Every tolerated-status or defensive branch is either reproduced or labelled defensive
+- [ ] Findings recorded with command, output, and date
+```


### PR DESCRIPTION
## What changed

New language-agnostic skill: `skills/common/verifying-external-behavior`, plus registration in `.claude-plugin/marketplace.json` (added to `python-library-complete` and `python-library-quality`, plus a standalone bundle so non-Python users can install it; `metadata.version` → 2.4.0) and a row in the README's Common table.

## The pattern that motivated it

A recurring, cross-language class of bug shows up repeatedly in integration code, and it is never a coding error — it is an *unverified belief* about someone else's system that shipped green:

- **A client library forwards a misspelled selector verbatim** instead of validating it against its own documented parameter list. The remote drops the unknown parameter, applies its default, and returns plausible-but-wrong records (frequently the authenticated user's own). Nothing raises. The only reliable check is intercepting the transport and reading the outbound query parameters — and the same libraries bind *positional* arguments in a per-endpoint order, so two identical-looking calls can differ in which argument lands where.
- **Status codes documented for the single-item form of a resource do not transfer to the collection form.** A "tolerate 410 when the feature is disabled" branch turns out to be unreachable because the list endpoint actually answers `200` with an empty array — so the real path falls through to the generic handler. (Reproduced live while writing this: the list form returns 200, the item form 410.)
- **List endpoints embed summary objects, not full entities**, which silently turns a "we already have the fields" fast path into an always-false check and the "fallback" per-item fetch into an N+1 common path.
- **Fakes encode the author's assumption, not the service's behaviour** — TTL/expiry sentinels, awaitable client factories, which exception a failure raises. Standing the real service up in a container once, and simulating the outage with a dead port rather than a mocked error, is what validates them.
- **Dry-run/resolve-only modes report success for problems that only surface in the real run** (e.g. a dependency form that resolves fine but hard-fails the build), because the dry run bought its speed by skipping exactly that step.
- Hand-written parser fixtures agree with the parser by construction, so a whitespace-strict regex can be green against every fixture and never match the live document.

The common remedy across all of these is the same and takes seconds: probe the exact call — same endpoint form, same version, same argument spelling — before designing around the answer, and record the command, output, and date so the finding can be re-checked instead of decaying into folklore.

## How a reader benefits

The skill gives concrete, copy-pasteable probe recipes (throwaway `uv run --no-project --with`, `curl` on both the collection and item URL, `unzip -l` on the built wheel, a one-minute container, a transport spy that prints the real outbound parameters), the rule for each failure class, and a pre-ship checklist. It complements `testing-strategy`'s false-green audit, which covers the test-side half; this covers the assumption-side half, before a test is written at all. Cross-referenced rather than duplicated.