### PR TITLE
[autopilot] skills: add shipping-build-artifacts (build scripts as a real gate)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "homepage": "https://github.com/wdm0006/python-skills",
-    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts"]
+    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts"]
   },
   "plugins": [
     {
@@ -35,7 +35,17 @@
         "./skills/python/mcp-servers",
         "./skills/python/llm-features",
         "./skills/common/rendering-untrusted-content",
-        "./skills/common/sync-jobs"
+        "./skills/common/sync-jobs",
+        "./skills/common/build-artifacts"
+      ]
+    },
+    {
+      "name": "shipping-build-artifacts",
+      "description": "Make the build step a real gate on what you distribute - scripts that fail instead of warning on a missing input, size checks bounded on both sides, file lists checked against the entrypoints they must cover, committed bundles that can't go stale, portable release shell, and artifact verification that runs before the upload",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/common/build-artifacts"
       ]
     },
     {
@@ -103,7 +113,8 @@
       "skills": [
         "./skills/python/packaging",
         "./skills/python/release-management",
-        "./skills/python/cli-development"
+        "./skills/python/cli-development",
+        "./skills/common/build-artifacts"
       ]
     },
     {
@@ -160,6 +171,7 @@
       "strict": false,
       "skills": [
         "./skills/javascript/browser-extensions",
+        "./skills/common/build-artifacts",
         "./skills/common/rendering-untrusted-content",
         "./skills/common/git-hygiene",
         "./skills/common/github-actions"

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ After installation, you can verify the skills are loaded by running:
 | **rendering-untrusted-content** | Render stored/authored/imported content into HTML without shipping XSS — enumerating autoescape bypasses (`\|safe`, `Markup`, `innerHTML`), sanitizing Markdown output with an allowlist (Markdown preserves raw HTML by design), keeping table-cell `style` so alignment survives, escaping on both the server and the DOM, and sanitization tests that assert on the rendered prose rather than the JSON-LD copy | — |
 | **keeping-git-repos-clean** | Prevent, detect, and remediate committed secrets and dev artifacts — .gitignore, `git rm --cached`, history scrubbing, credential rotation. Bundled into every language's plugin. | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
 | **verifying-external-behavior** | Confirm what a third-party library, remote API, build backend, or scraped document actually does before depending on it — throwaway probes that run in seconds, permissive clients that forward a misspelled selector instead of rejecting it, status codes that differ between the collection and item forms of a resource, summary response shapes that make a "we already have it" fast path always-false, fakes that only prove your code calls the fake, and dry-runs that skip the step that fails | — |
+| **shipping-build-artifacts** | Make the build step a real gate on what you distribute — build scripts that warn and exit 0 on a missing input, size checks with only an upper bound, hand-maintained file lists that drift from the entrypoints they must cover, committed bundles that go stale when only the source changes, GNU-only shell that aborts on the other OS, and verification that runs against the source tree instead of the artifact | — |
 | **running-resumable-sync-jobs** | Batch/sync jobs that fail honestly — exit codes that report partial failure, checkpoints safe to resume, per-item tolerance vs. fatal abort, unknown-vs-coerced-`0` in aggregated output, bounded per-page retries, dry-runs that mutate in-memory state identically, and compensating reserved quota | — |
 
 ## Plugin Bundles
@@ -159,12 +160,12 @@ After installation, you can verify the skills are loaded by running:
 - **swift-apps** — `building-swift-apps` + `keeping-git-repos-clean`.
 - **rust-crates** — `building-rust-crates` + `keeping-git-repos-clean`.
 - **scala-projects** — `building-scala-projects` + `keeping-git-repos-clean`.
-- **browser-extensions** — `building-browser-extensions` + `rendering-untrusted-content` + `keeping-git-repos-clean`.
+- **browser-extensions** — `building-browser-extensions` + `shipping-build-artifacts` + `rendering-untrusted-content` + `keeping-git-repos-clean`.
 
 ### Narrower Python bundles
 
 - **python-library-foundations** — project setup, code quality, testing strategy.
-- **python-library-distribution** — packaging, release management, CLI development.
+- **python-library-distribution** — packaging, release management, CLI development, build-artifact shipping.
 - **python-library-quality** — security audit, performance, API design, untrusted-content rendering, external-behavior verification, git hygiene.
 - **python-web-app** — web-app architecture (FastAPI, async SQLAlchemy, Stripe, Docker/Terraform deployment) + untrusted-content rendering.
 - **python-mcp-servers** — MCP servers (FastMCP tool design, error contracts, packaging, testing, prompt-injection awareness).
@@ -174,6 +175,7 @@ After installation, you can verify the skills are loaded by running:
 
 - **resumable-sync-jobs** — batch/sync jobs, cron tasks, importers, and paginated fetchers (partial-failure exit codes, resumable checkpoints, bounded retries, quota compensation).
 - **verifying-external-behavior** — integrating a dependency, endpoint, or build backend (probe the exact call, inspect outbound parameters, validate fakes against the real service, skip the dry-run shortcut).
+- **shipping-build-artifacts** — build/package scripts, `dist/` copy steps, committed compiled assets, and release workflows that upload a zip or installer (fail on missing inputs, bound size both ways, rebuild-and-diff committed bundles, verify the artifact before publishing).
 
 Every language bundle includes **keeping-git-repos-clean** — committed-secret and dev-artifact hygiene applies regardless of language.
 

--- a/skills/common/build-artifacts/SKILL.md
+++ b/skills/common/build-artifacts/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: shipping-build-artifacts
+description: Make the build step a real gate on what you actually distribute — build scripts that warn and exit 0 on a missing input, size checks with only an upper bound, hand-maintained file lists that drift from the entrypoints they must cover, committed bundles that go stale when only the source changes, GNU-only shell in release scripts that aborts on the other OS, and verification that runs against the source tree instead of the artifact. Use when writing or reviewing a build/package script, a `dist/` copy step, a release workflow that uploads a zip or installer, or a committed compiled asset.
+---
+
+# Shipping Build Artifacts
+
+Lint, type-check, and tests run against the source tree. What users install is a
+*different* set of bytes — assembled by a script that most gates never look at,
+then uploaded by a workflow that trusts whatever the script left behind. Every
+failure below ships a broken or stale artifact under fully green CI.
+
+## A script that warns and exits 0 is not a gate
+
+The shape is universal: a declared list of inputs, a copy loop, a friendly
+warning when one is missing.
+
+```js
+for (const f of DIST_FILES) {
+  if (!fs.existsSync(f)) {
+    console.warn(`Warning: ${f} not found, skipping`);   // build "succeeds"
+    continue;
+  }
+  fs.copyFileSync(f, path.join("dist", f));
+}
+```
+
+Move one required file aside and the script prints a line nobody reads, exits 0,
+and produces a `dist/` without it. Nothing downstream notices: the test job ran
+against the source tree, and the release job zips `dist/` and attaches it to a
+public release. The artifact is wholly non-functional — the entrypoint imports a
+file that isn't there — and the failure is discovered by users.
+
+```js
+const missing = DIST_FILES.filter((f) => !fs.existsSync(f));
+if (missing.length) {
+  console.error(`Missing build inputs: ${missing.join(", ")}`);
+  process.exit(1);
+}
+```
+
+The rule: inside a build script, `warn` may only describe something the artifact
+survives without. If you cannot say what still works when that file is absent, it
+is an error and the process must exit non-zero.
+
+## Bound the artifact size on *both* sides
+
+A packaging check with only a ceiling — "fail if the zip exceeds 500 KB" — is a
+cost guard, not a correctness one. A build that silently dropped half its files
+is *smaller*, so it passes the only check that exists.
+
+```js
+assert(bytes < 500 * 1024, "package too large");
+assert(bytes > 20 * 1024, "package suspiciously small — inputs likely missing");
+assert(entries.length === DIST_FILES.length, "package entry count mismatch");
+```
+
+Better still, assert on contents rather than a proxy: list the archive's entries
+and compare against the set the entrypoints require.
+
+## Derive the file list, or check it against the entrypoints
+
+`DIST_FILES` — like a build backend's `only-include`, or a hand-written
+`package_data` — is a *second* copy of "what this app is made of." The first copy
+is the manifest, the entry HTML, and the import graph. They drift in one
+direction: someone adds `utils.js`, references it from the popup, and forgets the
+copy list. The build stays green and the feature is dead in the packaged app.
+
+Either derive the list (bundle from the real entrypoints), or add a check that
+every path referenced by the manifest and by `<script src>` / `importScripts`
+exists in `dist/` after the build. A hand-maintained allowlist with no such check
+is a bug scheduled for a future commit.
+
+The same rule covers any place dependency or asset metadata is restated by hand —
+a standalone launcher script whose inline dependency header duplicates the
+project manifest's `dependencies`, for instance. If duplication is unavoidable,
+add a test that normalizes both lists and compares them, so drift fails in CI
+instead of at a user's install.
+
+## Committed build outputs go stale silently
+
+When a compiled or minified bundle is committed and served directly, *the bundle
+is the program* and its source is a comment until someone rebuilds. Editing only
+the source ships nothing; the page keeps serving the previous bundle, and no test
+or linter says a word.
+
+- Rebuild in CI and `diff` against the committed output; fail on drift.
+- Pin the builder to an exact version — the diff is only meaningful if the output
+  is byte-deterministic.
+- Confirm that determinism once across the environments people actually use
+  (native toolchain vs. container image), so the check is runnable locally too.
+
+```bash
+npx -y esbuild@0.24.2 src/app.jsx --jsx=transform --minify --outfile=/tmp/app.js
+diff /tmp/app.js web/app.js
+```
+
+Rebuild and commit the output in the **same commit** as the source change. A
+"rebuild bundles" follow-up commit means every commit in between shipped code
+that does not match its source.
+
+## Release scripts run on an OS you didn't write them on
+
+Build scripts are written on a developer machine and executed on the runner.
+GNU-only tooling is the usual break, and `set -e` turns it into a total abort on
+a line that merely reads a version number:
+
+```bash
+# Breaks under BSD grep (macOS): -P / lookbehind are GNU extensions.
+VERSION=$(grep -Po '(?<=^version = ")[^"]+' pyproject.toml)
+```
+
+Read structured metadata with a parser instead of a regex, and prefer a runtime
+you already depend on:
+
+```bash
+VERSION=$(python -c 'import tomllib;print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+VERSION=$(jq -r .version package.json)
+```
+
+Then pin it with a test: the version the build script extracts must equal the
+version declared in the project manifest. Without that, the failure mode is a
+release tagged `v1.4.0` whose artifact reports `1.3.2`, and nothing in the
+pipeline disagrees.
+
+## Verify the artifact, then publish — in that order, in that job
+
+Attaching a file to a public release, pushing a tag, or uploading to a registry
+are the least reversible steps in the project. The verification must sit between
+the build and the upload, in the same job. A separate green "test" job proves
+nothing about the artifact: it ran against the source tree.
+
+Minimum ordering:
+
+1. Build.
+2. List every entry in the artifact and assert the entrypoints are present.
+3. Install or load it **from a directory the source tree is not on the load path
+   of**, and exercise one real symbol or command — not merely that a top-level
+   name resolves.
+4. Only then upload.
+
+Step 3 is the one that gets skipped, and it is the only step that distinguishes
+"the archive has files in it" from "the thing runs." Run it somewhere else on
+disk, or it passes against the sources and proves nothing.
+
+For language-specific artifact inspection (wheels, sdists, console scripts), see
+`packaging-python-libraries`. For pinning the tools that produce and check these
+artifacts, see the CI tooling section of `setting-up-python-libraries`.
+
+## Checklist
+
+```
+Build script:
+- [ ] Missing declared input → non-zero exit, not a warning
+- [ ] Size assertions have a floor as well as a ceiling
+- [ ] File list is derived, or checked against manifest/entry-HTML references
+- [ ] Duplicated dependency metadata has a drift test
+- [ ] No GNU-only flags (grep -P, sed -i'' semantics) in scripts CI also runs
+- [ ] Version extracted with a parser, and asserted equal to the declared version
+
+Committed build outputs:
+- [ ] CI rebuilds and diffs; drift fails
+- [ ] Builder pinned to an exact version; output confirmed deterministic
+- [ ] Output committed alongside the source change, not in a follow-up
+
+Release:
+- [ ] Artifact contents listed and asserted before upload
+- [ ] Artifact installed/loaded from outside the repo and exercised
+- [ ] Verification runs in the same job as the upload, before it
+```


### PR DESCRIPTION
Adds a new language-agnostic skill: `skills/common/build-artifacts` (`shipping-build-artifacts`).

## Motivating pattern

Across several projects the same gap kept producing broken or stale releases under fully green CI: **every quality gate runs against the source tree, but the thing users install is `dist/`** — assembled by a script nothing else inspects, then uploaded by a workflow that trusts whatever it left behind. Concrete recurrences that the skill encodes:

- A packaging script that `console.warn`s and exits 0 when a declared input file is missing, producing a `dist/` without it. Lint and tests ran against the sources, the size check only had an *upper* bound (a broken, smaller package passes), and the release job attached the resulting non-functional zip to a public release.
- A hand-maintained copy list that is a second, silently drifting copy of what the manifest and entry HTML actually reference — and the same shape wherever dependency metadata is restated by hand in a launcher script alongside a project manifest.
- A committed minified bundle served directly while its source file is edited alone: the change ships nothing and no gate complains. Fixed by a pinned-builder rebuild-and-diff in CI, after confirming the builder output is byte-deterministic across native and container runs.
- A release script extracting a version with a GNU-only `grep -P` lookbehind, which aborts the whole `set -e` build on the other OS — replaced by reading the manifest with a parser plus a test asserting extracted version == declared version.
- Artifact verification that runs in a separate job against the sources, so it never distinguishes "the archive has files in it" from "the thing runs."

## What changed

- New `skills/common/build-artifacts/SKILL.md` with the six sections above and a checklist.
- Registered in `python-library-complete`, `python-library-distribution`, and `browser-extensions`, plus a standalone `shipping-build-artifacts` bundle; `metadata.version` bumped to 2.5.0 with two new keywords.
- README skills table and bundle list updated.

## Benefit

A reader gets a concrete, cross-language rule set for making the build step a gate rather than a formality — fail on missing inputs, bound size on both sides, check the file list against the entrypoints, keep committed build outputs honest, keep release shell portable, and verify the artifact from outside the repo *before* the irreversible upload. Language-specific wheel/sdist inspection is cross-referenced rather than duplicated.