### PR TITLE
[autopilot] skills: prevent empty evaluator clean passes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "homepage": "https://github.com/wdm0006/python-skills",
     "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment"]
   },
@@ -78,7 +78,7 @@
     },
     {
       "name": "python-llm-features",
-      "description": "Build application features on top of an LLM API - prompt surfaces that drift, structured outputs, context budgeting, model config wiring, live-model tests kept out of CI, stochastic accuracy evaluation, and truthful presentation of model output",
+      "description": "Build application features on top of an LLM API - prompt surfaces that drift, filtered evaluator sets that cannot silently become clean passes, model config wiring, live-model tests kept out of CI, stochastic accuracy evaluation, and truthful presentation of model output",
       "source": "./",
       "strict": false,
       "skills": [

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ After installation, you can verify the skills are loaded by running:
 | **reviewing-python-libraries** | Comprehensive library reviews across all quality dimensions | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
 | **building-python-web-apps** | Opinionated reference architecture for production web apps — FastAPI, async SQLAlchemy/Postgres, Stripe billing, Jinja or SPA frontends, and Dockerized deployment via Terraform | Production web app patterns |
 | **building-python-mcp-servers** | Robust Python MCP servers with FastMCP — tool design, error contracts, CLI/subprocess wrapping, single-file vs packaged distribution, testing, and prompt-injection awareness | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
-| **building-llm-backed-features** | Application features on top of an LLM API — the four prompt surfaces that drift apart, structured-output field descriptions as prompt, one shared context limiter, config wiring validated at boot, live-model tests kept out of CI, stochastic accuracy evaluation, and output that doesn't over-claim | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
+| **building-llm-backed-features** | Application features on top of an LLM API — prompt surfaces that drift apart, filtered evaluator sets that cannot silently become clean passes, config wiring validated at boot, live-model tests kept out of CI, stochastic accuracy evaluation, and output that doesn't over-claim | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
 
 ### Go
 

--- a/skills/python/llm-features/SKILL.md
+++ b/skills/python/llm-features/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-llm-backed-features
-description: Builds application features on top of an LLM API in Python — prompt surfaces that drift apart, structured outputs, context budgeting, model/config wiring, keeping live-model calls out of default CI, evaluating stochastic output, and presenting model output truthfully. Use when adding an LLM call to an app, designing structured outputs or prompt templates, wiring model config, or testing/evaluating LLM-backed analysis.
+description: Builds application features on top of an LLM API in Python — prompt surfaces that drift apart, structured outputs, context budgeting, model/config wiring, filtered evaluator sets, keeping live-model calls out of default CI, evaluating stochastic output, and presenting model output truthfully. Use when adding an LLM call to an app, designing structured outputs or prompt templates, filtering audit rules, wiring model config, or testing/evaluating LLM-backed analysis.
 ---
 
 # Building LLM-Backed Features
@@ -128,6 +128,48 @@ monkeypatch.setattr(Analyzer, "_score", Mock(side_effect=[12.0, 30.5]))
 That runs in milliseconds and covers the wiring, chunking, and thresholding —
 which is where the bugs actually are.
 
+## An empty evaluator set is not a clean pass
+
+Audit and classification services often filter rules to the categories requested
+by the caller. If the filter disables every rule and the evaluator treats no
+results as no findings, the response becomes a confident clean pass: a perfect
+score, zero failures, and zero evidence. That is absence of evaluation, not
+evidence of safety.
+
+Fail closed when a requested filter selects nothing:
+
+```python
+selected = [rule for rule in rules if rule.category in requested_categories]
+if not selected:
+    raise NoApplicableRules(requested_categories)
+
+results = await evaluate_all(selected, document)
+```
+
+Composite rules need explicit semantics. A rule that evaluates all categories
+must not be removed merely because its registry tag names one category. Either
+model its coverage as a set and filter on intersection, or designate it as
+always applicable:
+
+```python
+selected = [
+    rule
+    for rule in rules
+    if rule.covers_all or rule.categories & requested_categories
+]
+```
+
+Prefer selecting a local list over mutating shared `enabled` flags. If the
+framework requires temporary mutation, record exactly which rules this request
+disabled and restore only those in `finally`; blindly re-enabling every rule
+overwrites administrator or tenant configuration.
+
+Regression tests must ask for a category not named by the composite rule and
+assert that evaluation still ran. Assert evidence, not only the final score:
+the evaluator call count, the applied rule identifiers, and a nonzero
+`rules_evaluated` count. Also test a genuinely unsupported category and require
+an explicit error or `not_evaluated` status—never the normal pass shape.
+
 ## Evaluate accuracy as its own job, and record raw outcomes
 
 Model output is stochastic, so a single-run assertion is a coin flip and belongs
@@ -193,6 +235,9 @@ Tests & evaluation:
 - [ ] Live-model modules marked; default/CI run deselects them
 - [ ] CI reproduced with the full marker expression
 - [ ] Real analysis path covered with a pre-populated model cache (no network)
+- [ ] Category filters cannot reduce evaluation to zero and return a clean pass
+- [ ] Composite rules declare their coverage; temporary rule state is restored
+      in `finally` without re-enabling rules disabled before the request
 - [ ] Accuracy fixture is versioned, has negative cases, runs each case N times,
       and persists raw outcomes
 


### PR DESCRIPTION
What changed

- Sharpens the LLM-features skill with an explicit invariant: filtering an audit or classification rule set to zero checks must never produce the normal clean-pass response.
- Documents composite-rule coverage, request-local selection, safe restoration of temporarily disabled rules, and evidence-based regression assertions.
- Updates the skill catalog description and advances the marketplace minor version.

Pattern motivating the change

Category filtering can accidentally exclude the only evaluator when that evaluator covers multiple categories but carries a single registry tag. If an empty result set is then interpreted as no findings, the system returns a perfect score with zero evidence. Temporary enablement changes can also overwrite pre-existing administrator or tenant configuration unless only request-owned changes are restored in a finally block.

Reader benefit

Readers get a concrete implementation and testing standard that prevents “not evaluated” from being reported as “all clear,” while preserving configured rule state.