### PR TITLE
[autopilot] skills: document lint rules that silently skip private names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "homepage": "https://github.com/wdm0006/python-skills",
     "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment"]
   },

--- a/skills/python/code-quality/SKILL.md
+++ b/skills/python/code-quality/SKILL.md
@@ -110,6 +110,60 @@ if name is not "":   # CPython interning makes it *sometimes* work — never rel
 if name != "":
 ```
 
+## A Rule You Enabled Isn't a Rule That Fires
+
+Linters ship exemptions, and the costly ones are invisible: the rule is in
+`select`, the job is green, and the class of mistake you believed was policed
+walks straight through. Before relying on a check to protect something, write
+the violation on purpose once and confirm it gets reported.
+
+The Ruff default that bites hardest is `dummy-variable-rgx`. It exists so
+`_`-prefixed throwaways don't trip unused-variable checks, but its default
+pattern matches **any** leading-underscore name — so `F811` (redefinition of an
+unused name) ignores every private helper in the codebase.
+
+```python
+# module.py — two module-level definitions. The FIRST one is dead code.
+def _is_rate_limited(response):          # never called; editing it has no effect
+    return response.status_code == 403
+
+def _is_rate_limited(response):          # this is the one that wins
+    return response.status_code == 403 and "rate limit" in response.text.lower()
+```
+
+`ruff check --select F811` passes clean on that file. Rename both to
+`is_rate_limited` and it fires immediately (verified on ruff 0.16). The gate is
+working — the *name* opted out of it.
+
+This shape shows up most often after two branches independently add the same
+module-level helper and a conflict resolution keeps both sides. Nothing goes
+red; the bodies usually agree at first; then someone patches the dead copy and
+cannot work out why the behaviour didn't change.
+
+Prefer fixing it in config, so the check actually covers private names:
+
+```toml
+[tool.ruff.lint]
+dummy-variable-rgx = "^_$"   # only a bare `_` is a throwaway
+```
+
+State the tradeoff honestly before adopting it: `_, keep = pair()` stays silent,
+but `_unused = compute()` now trips `F841`. In a codebase that leans on `_name`
+throwaways that is real noise — delete the assignment or use a bare `_` rather
+than reverting the regex.
+
+Independently, after resolving a conflict in a module both branches edited, look
+for duplicated definitions directly — this catches shadowing the linter's
+config can't:
+
+```bash
+grep -oE '^(def|class) [A-Za-z_][A-Za-z0-9_]*' module.py | sort | uniq -d
+```
+
+The habit generalizes past Ruff: when a check is load-bearing, introduce the
+mistake once and watch it get caught, the same way a regression test is only
+trustworthy after you've seen it go red.
+
 ## Fail Loud: Don't Degrade Silently
 
 The costliest bugs aren't crashes — they're failures that look like success. Code
@@ -303,6 +357,8 @@ Code Quality:
 - [ ] Batch loops collect per-item errors instead of a bare `continue`
 - [ ] Truthiness guards don't swallow valid 0/False/"" (guard on `is None`)
 - [ ] No `is`/`is not` against literals (use ==/!=)
+- [ ] Load-bearing lint rules verified to fire (F811 skips `_`-prefixed names under the default `dummy-variable-rgx`)
+- [ ] No duplicate module-level `def`/`class` names after a conflict resolution
 - [ ] Deterministic output: sort before serializing; seed/inject all RNGs (both `random` and `numpy`)
 - [ ] py.typed marker present
 ```


### PR DESCRIPTION
## What changed

New section in `skills/python/code-quality` — **"A Rule You Enabled Isn't a Rule That Fires"** — plus two checklist lines and a marketplace `metadata.version` bump. No other skill touched.

## The pattern that motivated it

Recurring across several codebases: a lint rule is in `select`, CI is green, and the exact class of mistake it was supposed to police walks straight through because of a default *exemption*.

The concrete instance is Ruff's `dummy-variable-rgx`. Its default pattern matches **any** leading-underscore name, so `F811` (redefinition of an unused name) ignores every private helper. When two branches independently add the same module-level `_helper` and a conflict resolution keeps both sides, nothing goes red — the first definition is dead code, the bodies agree at first, and later someone patches the dead copy and can't work out why the behaviour didn't change.

Verified empirically on ruff 0.16.1 before writing it up:

- `ruff check --select F811` passes clean on a file with two `def _helper()` at module scope; renaming both to `helper` makes it fire immediately.
- `dummy-variable-rgx = "^_$"` makes F811 cover private names. The tradeoff is stated honestly in the skill: `_, keep = pair()` stays silent, but `_unused = compute()` then trips `F841`.

## How a reader benefits

They get the config knob and its cost, a `grep | sort | uniq -d` check for duplicate module-level definitions to run after resolving a conflict in a shared module, and the generalizable habit — when a check is load-bearing, introduce the violation once and watch it get caught, the same discipline a regression test needs before it's trustworthy.