### PR TITLE
Make changelog version insertion idempotent

### DIFF
--- a/skills/python/release-management/scripts/bump_version.py
+++ b/skills/python/release-management/scripts/bump_version.py
@@ -127,6 +127,12 @@ def update_changelog(
         return False
 
     content = changelog.read_text()
+
+    # Already released: leave the file untouched so retried releases don't
+    # insert a second heading for the same version.
+    if re.search(rf'(?m)^##\s*\[?{re.escape(new_version)}\]?(?![\w.\-])', content):
+        return False
+
     today = date.today().isoformat()
 
     # Match the [Unreleased] heading only (not the [Unreleased]: link reference

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,97 @@
+import importlib.util
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "skills"
+    / "python"
+    / "release-management"
+    / "scripts"
+    / "bump_version.py"
+)
+SPEC = importlib.util.spec_from_file_location("bump_version", SCRIPT)
+assert SPEC and SPEC.loader
+BUMP_VERSION = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = BUMP_VERSION
+SPEC.loader.exec_module(BUMP_VERSION)
+
+
+CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+- Restored parity with the 1.2.3 behaviour described in the old notes.
+
+## [1.2.2] - 2024-01-01
+
+### Added
+- Initial release.
+
+[Unreleased]: https://example.com/compare/v1.2.2...HEAD
+[1.2.3]: https://example.com/releases/v1.2.3
+[1.2.2]: https://example.com/releases/v1.2.2
+"""
+
+
+class UpdateChangelogTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.project = Path(self.temp_dir.name)
+        self.changelog = self.project / "CHANGELOG.md"
+        self.changelog.write_text(CHANGELOG)
+
+    def headings(self, version):
+        return re.findall(
+            rf'(?m)^##\s*\[{re.escape(version)}\] - \d{{4}}-\d{{2}}-\d{{2}}$',
+            self.changelog.read_text(),
+        )
+
+    def test_first_update_inserts_one_heading_below_unreleased(self):
+        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+
+        self.assertEqual(len(self.headings("1.2.3")), 1)
+        lines = self.changelog.read_text().splitlines()
+        unreleased = lines.index("## [Unreleased]")
+        self.assertEqual(lines[unreleased + 1], "")
+        self.assertRegex(lines[unreleased + 2], r'^## \[1\.2\.3\] - \d{4}-\d{2}-\d{2}$')
+
+    def test_repeated_update_is_a_no_op(self):
+        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+        after_first = self.changelog.read_bytes()
+
+        self.assertFalse(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+
+        self.assertEqual(self.changelog.read_bytes(), after_first)
+        self.assertEqual(len(self.headings("1.2.3")), 1)
+
+    def test_version_mentioned_only_in_prose_or_links_is_not_a_release_heading(self):
+        # The fixture already cites 1.2.3 in release notes and in a link
+        # reference, so the first insertion must still happen.
+        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+        self.assertEqual(len(self.headings("1.2.3")), 1)
+
+    def test_other_versions_are_still_inserted(self):
+        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.3.0"))
+
+        self.assertEqual(len(self.headings("1.2.3")), 1)
+        self.assertEqual(len(self.headings("1.3.0")), 1)
+
+    def test_existing_heading_for_a_longer_version_does_not_block_a_prefix(self):
+        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.30"))
+        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+
+        self.assertEqual(len(self.headings("1.2.3")), 1)
+        self.assertEqual(len(self.headings("1.2.30")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #62

## What changed

`update_changelog` in `skills/python/release-management/scripts/bump_version.py` always inserted a release heading below `## [Unreleased]`, so calling it twice for the same version returned `True` both times and left two identical `## [X.Y.Z] - <date>` headings. Since the CLI rejects only downgrades, re-running a release command after an interrupted workflow silently corrupted the changelog.

It now checks for an existing structured release heading before writing. If one is present, the file is left untouched and the function returns `False`, reusing the existing "no update" contract that the caller already handles.

The check is anchored to a level-2 heading and bounded on the right (`^##\s*\[?<version>\]?(?![\w.\-])`), so:

- a version mentioned in release notes or in a `[X.Y.Z]: https://...` link reference is not mistaken for a heading;
- an existing `## [1.2.30]` heading does not block inserting `1.2.3`;
- both `## [1.2.3] - 2026-01-01` and `## 1.2.3 - 2026-01-01` count as released.

Version calculation and the non-changelog file updates are unchanged.

## Verification

New stdlib `unittest` module `tests/test_bump_version.py` loads the repository's actual `bump_version.py` (same `importlib.util.spec_from_file_location` pattern as the existing scaffolder test) and drives `update_changelog` against a real `CHANGELOG.md` in a `TemporaryDirectory`.

```
$ uv run python -m unittest tests.test_bump_version tests.test_create_project
Ran 10 tests in 0.023s
OK
```

Mutation-tested to confirm the new tests are not vacuous (`__pycache__` cleared and `PYTHONDONTWRITEBYTECODE=1` set for each run, so the interpreter really loaded the mutated source):

| Mutation | Result |
|---|---|
| Guard disabled (`if False:`) — the original bug | `test_repeated_update_is_a_no_op` fails (second call returns `True`) |
| Guard replaced with a bare substring check (`new_version in content`) — the plausible over-broad fix | 5 failures, including `test_version_mentioned_only_in_prose_or_links_is_not_a_release_heading` |
| Right boundary `(?![\w.\-])` dropped from the pattern | `test_existing_heading_for_a_longer_version_does_not_block_a_prefix` fails |

The suite is green again after restoring the file.

Lint: `uvx ruff check` on `bump_version.py` reports the same 3 pre-existing default-rule findings (`EXE001`, `DTZ011`, `SIM102`) before and after this change — none are introduced here. The new test file's only finding is the `I001` blank-line style that `tests/test_create_project.py` already uses, kept for consistency with the existing test module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)