### PR TITLE
[autopilot] skills: harden SSRF guidance against DNS rebinding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.9.0",
+    "version": "2.10.0",
     "homepage": "https://github.com/wdm0006/python-skills",
     "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy"]
   },

--- a/skills/python/security-audit/SKILL.md
+++ b/skills/python/security-audit/SKILL.md
@@ -85,6 +85,8 @@ Code:
 - [ ] No weak crypto (MD5/SHA1)
 - [ ] Input validation on external data
 - [ ] Path traversal prevention
+- [ ] SSRF fetches connect to the validated IP on every redirect hop (DNS rebinding safe)
+- [ ] SSRF deny policy covers IPv4/IPv6 and CGNAT (`100.64.0.0/10`)
 
 Dependencies:
 - [ ] pip-audit clean

--- a/skills/python/security-audit/VULNERABILITIES.md
+++ b/skills/python/security-audit/VULNERABILITIES.md
@@ -139,14 +139,61 @@ resp = requests.get(url)
 ```
 
 ```python
-# Fixed — allowlist the scheme and host, block private ranges
+# Still vulnerable — validation and connection perform separate DNS lookups
 parsed = urllib.parse.urlparse(url)
-if parsed.scheme not in ("https",) or parsed.hostname not in ALLOWED_HOSTS:
+addresses = socket.getaddrinfo(parsed.hostname, 443)
+if any(ipaddress.ip_address(item[4][0]).is_private for item in addresses):
     raise ValueError("Disallowed URL")
-resp = requests.get(url, timeout=5, allow_redirects=False)
+resp = requests.get(url, timeout=5)  # resolves the hostname again
 ```
 
-Validate against an allowlist rather than a denylist, resolve the hostname and reject private/loopback/link-local IPs, and disable redirects so a permitted host cannot bounce the request to an internal one.
+That check has two holes. An attacker-controlled hostname can resolve to a public
+address during validation and an internal address when the HTTP client resolves it
+again (DNS rebinding). Redirects create the same gap at every hop.
+
+The safe invariant is **connect only to an address returned by validation**:
+
+```python
+CGNAT = ipaddress.ip_network("100.64.0.0/10")
+
+def address_is_blocked(text: str) -> bool:
+    address = ipaddress.ip_address(text)
+    return (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+        or address in CGNAT
+    )
+
+# Pseudocode: the transport API differs by HTTP client.
+target = validate_url_and_resolve(url)  # returns original host + approved IPs
+response = transport.request(
+    connect_ip=choose(target.approved_ips),
+    authority=target.hostname,           # HTTP Host / HTTP/2 :authority
+    tls_server_name=target.hostname,     # certificate verification and SNI
+)
+```
+
+Do not substitute `ip_address(...).is_private` for an explicit deny policy:
+Python does not classify carrier-grade NAT (`100.64.0.0/10`) as private, even
+though it is not a safe public destination for an SSRF fetcher. Include IPv4 and
+IPv6 results, and reject the hostname if **any** resolved address is forbidden;
+otherwise an attacker can influence which answer the client selects.
+
+If redirects are enabled, handle them manually with a small hop limit. Parse,
+allowlist, resolve, validate, and pin the connection again for every `Location`.
+Preserve the redirected URL's original authority and TLS server name while the
+socket connects to the approved IP. Disabling redirects is simpler and preferred
+when the product does not require them.
+
+Tests must prove the validation-to-connection binding, not merely mock the
+validator: simulate DNS returning public-then-loopback answers and assert that the
+transport either uses the retained public IP or rejects the request without a
+second unconstrained lookup. Repeat the test for a redirect target and include
+CGNAT, IPv6 loopback, link-local, and mixed public/private answer sets.
 
 ## XXE
 


### PR DESCRIPTION
## What changed

- Replaces a validate-then-resolve SSRF example with the invariant that the transport must connect to an address retained from validation.
- Requires every redirect hop to be parsed, resolved, validated, and IP-pinned while preserving the original HTTP authority and TLS SNI.
- Adds an explicit CGNAT deny range and tests for rebinding, mixed DNS answers, redirects, and IPv4/IPv6 special-use addresses.

## Pattern promoted

Resolving a hostname during validation is insufficient when the HTTP client performs a second DNS lookup: an attacker-controlled name can return a public address first and an internal address at connection time. Redirects repeat that exposure at every hop, and a generic private-address predicate does not cover every non-public range, including carrier-grade NAT.

## Reader benefit

Readers get a concrete transport-level security invariant and regression-test checklist that closes the gap between URL validation and the socket that actually connects.

## Validation

- `uv run --no-project --with pytest pytest -q` (10 passed, 5 subtests passed)
- Manifest JSON parse
- Runtime assertion of CGNAT classification behavior
- `git diff --check`