### PR TITLE
Gate marketplace and README catalog consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Install a per-language bundle:
 # Swift / Apple platforms — Xcode build & CI, signing, Keychain, CloudKit/SwiftData, TestFlight releases
 /plugin install swift-apps@dev-skills
 
+# Swift releases — TestFlight and App Store delivery
+/plugin install shipping-swift-apps@dev-skills
+
 # Rust — Cargo layout, fmt/clippy/test gate, MSRV, crates.io publishing
 /plugin install rust-crates@dev-skills
 
@@ -55,6 +58,28 @@ Or install a narrower Python bundle:
 
 # Python MCP servers for LLM clients (FastMCP)
 /plugin install python-mcp-servers@dev-skills
+
+# LLM-backed Python features
+/plugin install python-llm-features@dev-skills
+```
+
+Or install a language-agnostic bundle:
+
+```
+# Resumable batch and synchronization jobs
+/plugin install resumable-sync-jobs@dev-skills
+
+# Verify third-party libraries, APIs, build backends, and scraped documents
+/plugin install verifying-external-behavior@dev-skills
+
+# Build and verify release artifacts
+/plugin install shipping-build-artifacts@dev-skills
+
+# Reproduce CI failures locally
+/plugin install reproducing-ci-locally@dev-skills
+
+# Keep user-facing facts consistent across product surfaces
+/plugin install shipping-across-surfaces@dev-skills
 ```
 
 ### Alternative: Local Installation
@@ -148,6 +173,7 @@ After installation, you can verify the skills are loaded by running:
 |-------|-------------|----------|
 | **rendering-untrusted-content** | Render stored/authored/imported content into HTML without shipping XSS — enumerating autoescape bypasses (`\|safe`, `Markup`, `innerHTML`), sanitizing Markdown output with an allowlist (Markdown preserves raw HTML by design), keeping table-cell `style` so alignment survives, escaping on both the server and the DOM, and sanitization tests that assert on the rendered prose rather than the JSON-LD copy | — |
 | **keeping-git-repos-clean** | Prevent, detect, and remediate committed secrets and dev artifacts — .gitignore, `git rm --cached`, history scrubbing, credential rotation. Bundled into every language's plugin. | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
+| **running-github-actions-efficiently** | Build GitHub Actions workflows that gate the intended work — focused triggers, pinned toolchains, explicit permissions, reproducible local commands, and jobs that fail when their checks fail | — |
 | **verifying-external-behavior** | Confirm what a third-party library, remote API, build backend, or scraped document actually does before depending on it — throwaway probes that run in seconds, permissive clients that forward a misspelled selector instead of rejecting it, status codes that differ between the collection and item forms of a resource, summary response shapes that make a "we already have it" fast path always-false, fakes that only prove your code calls the fake, and dry-runs that skip the step that fails | — |
 | **shipping-build-artifacts** | Make the build step a real gate on what you distribute — build scripts that warn and exit 0 on a missing input, size checks with only an upper bound, hand-maintained file lists that drift from the entrypoints they must cover, committed bundles that go stale when only the source changes, GNU-only shell that aborts on the other OS, and verification that runs against the source tree instead of the artifact | — |
 | **running-resumable-sync-jobs** | Batch/sync jobs that fail honestly — exit codes that report partial failure, checkpoints safe to resume, per-item tolerance vs. fatal abort, unknown-vs-coerced-`0` in aggregated output, bounded per-page retries, dry-runs that mutate in-memory state identically, and compensating reserved quota | — |

--- a/tests/test_marketplace_catalog.py
+++ b/tests/test_marketplace_catalog.py
@@ -1,0 +1,77 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+MANIFEST = ROOT / ".claude-plugin" / "marketplace.json"
+README = ROOT / "README.md"
+
+README_SECTIONS = {
+    "common": "Common (language-agnostic)",
+    "go": "Go",
+    "javascript": "JavaScript / Browser Extensions",
+    "python": "Python",
+    "rust": "Rust",
+    "scala": "Scala",
+    "swift": "Swift / Apple Platforms",
+}
+
+
+def read_section(markdown, heading):
+    match = re.search(
+        rf"^### {re.escape(heading)}\n(?P<body>.*?)(?=^### |^## |\Z)",
+        markdown,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"README section not found: {heading}")
+    return match.group("body")
+
+
+def read_frontmatter_name(skill_file):
+    contents = skill_file.read_text()
+    match = re.match(r"---\n(?P<frontmatter>.*?)\n---\n", contents, re.DOTALL)
+    if match is None:
+        raise AssertionError(f"frontmatter not found: {skill_file.relative_to(ROOT)}")
+    name = re.search(r"^name:\s*(?P<name>\S+)\s*$", match.group("frontmatter"), re.MULTILINE)
+    if name is None:
+        raise AssertionError(f"frontmatter name not found: {skill_file.relative_to(ROOT)}")
+    return name.group("name")
+
+
+class MarketplaceCatalogTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads(MANIFEST.read_text())
+        cls.readme = README.read_text()
+
+    def test_readme_install_commands_match_declared_bundles_and_marketplace(self):
+        commands = re.findall(r"^/plugin install ([^@\s]+)@([^\s]+)$", self.readme, re.MULTILINE)
+        declared_bundles = {plugin["name"] for plugin in self.manifest["plugins"]}
+
+        self.assertEqual({bundle for bundle, _ in commands}, declared_bundles)
+        self.assertEqual({marketplace for _, marketplace in commands}, {self.manifest["name"]})
+        self.assertEqual(len(commands), len(declared_bundles), "install commands must be unique")
+
+    def test_manifest_skill_paths_and_readme_catalog_entries(self):
+        skill_paths = {
+            Path(skill_path.removeprefix("./"))
+            for plugin in self.manifest["plugins"]
+            for skill_path in plugin["skills"]
+        }
+
+        for skill_path in sorted(skill_paths):
+            with self.subTest(skill_path=skill_path):
+                skill_file = ROOT / skill_path / "SKILL.md"
+                self.assertTrue(skill_file.is_file(), f"missing {skill_file.relative_to(ROOT)}")
+
+                namespace = skill_path.parts[1]
+                section = read_section(self.readme, README_SECTIONS[namespace])
+                name = read_frontmatter_name(skill_file)
+                self.assertRegex(section, rf"(?m)^\| \*\*{re.escape(name)}\*\* \|")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #58

## Summary

- documents install commands for every bundle currently declared by the marketplace
- adds the missing `running-github-actions-efficiently` Common catalog entry
- adds a standard-library contract test covering bundle/install parity, marketplace slugs, referenced `SKILL.md` files, and frontmatter names in the appropriate README catalog
- leaves CI workflow wiring to the shared repository gate tracked separately

## Verification

- `uv run python -m unittest discover -s tests -v` — 12 tests passed
- `uvx ruff check --select E4,E7,E9,F tests/test_marketplace_catalog.py` — passed
- `git diff --check` — passed
- Mutation checks confirmed the catalog tests fail for a removed install command, an undeclared bundle/wrong marketplace slug, a missing `SKILL.md`, and an uncataloged frontmatter name.
