### PR TITLE
Target project version in pyproject updates

### DIFF
--- a/skills/python/release-management/scripts/bump_version.py
+++ b/skills/python/release-management/scripts/bump_version.py
@@ -11,6 +11,7 @@ Usage:
 import argparse
 import re
 import sys
+import tomllib
 from datetime import date
 from pathlib import Path
 
@@ -23,9 +24,11 @@ def get_current_version(project_path: Path) -> str | None:
     if not pyproject.exists():
         return None
 
-    content = pyproject.read_text()
-    match = re.search(r'version\s*=\s*"([^"]+)"', content)
-    return match.group(1) if match else None
+    with pyproject.open("rb") as file:
+        project = tomllib.load(file).get("project", {})
+
+    version = project.get("version")
+    return version if isinstance(version, str) else None
 
 
 def parse_version(version: str) -> tuple[int, int, int]:
@@ -83,13 +86,26 @@ def update_version(
 
     # pyproject.toml
     pyproject = project_path / "pyproject.toml"
-    if update_file(
-        pyproject,
-        r'version\s*=\s*"[^"]+"',
-        f'version = "{new_version}"',
-        dry_run,
-    ):
-        updated_files.append(str(pyproject))
+    if pyproject.exists():
+        content = pyproject.read_text()
+        project_table = re.search(
+            r'(?ms)^[ \t]*\[project\][ \t]*(?:#.*)?$(.*?)(?=^[ \t]*\[|\Z)',
+            content,
+        )
+        if project_table:
+            body_start, body_end = project_table.span(1)
+            body = content[body_start:body_end]
+            new_body = re.sub(
+                r'(?m)^(\s*version\s*=\s*)"[^"]+"',
+                rf'\g<1>"{new_version}"',
+                body,
+                count=1,
+            )
+            new_content = content[:body_start] + new_body + content[body_end:]
+            if new_content != content:
+                if not dry_run:
+                    pyproject.write_text(new_content)
+                updated_files.append(str(pyproject))
 
     # Top-level package __init__.py (src/<package>/__init__.py), not every subpackage.
     src = project_path / "src"

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -39,6 +39,45 @@ CHANGELOG = """\
 [1.2.2]: https://example.com/releases/v1.2.2
 """
 
+PYPROJECT = """\
+[tool.before]
+version = "9.9.9"
+
+[project]
+name = "example"
+version = "1.2.3"
+description = "A version = \\"value\\" example"
+
+[tool.after]
+version = "8.8.8"
+"""
+
+
+class ProjectVersionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.project = Path(self.temp_dir.name)
+        self.pyproject = self.project / "pyproject.toml"
+        self.pyproject.write_text(PYPROJECT)
+
+    def test_get_current_version_reads_project_table(self):
+        self.assertEqual(BUMP_VERSION.get_current_version(self.project), "1.2.3")
+
+    def test_update_changes_only_project_version(self):
+        expected = PYPROJECT.replace('version = "1.2.3"', 'version = "1.2.4"')
+
+        updated = BUMP_VERSION.update_version(self.project, "1.2.4")
+
+        self.assertEqual(updated, [str(self.pyproject)])
+        self.assertEqual(self.pyproject.read_text(), expected)
+
+    def test_missing_project_version_uses_existing_failure_path(self):
+        self.pyproject.write_text('[tool.example]\nversion = "9.9.9"\n\n[project]\nname = "example"\n')
+
+        self.assertIsNone(BUMP_VERSION.get_current_version(self.project))
+        self.assertEqual(BUMP_VERSION.update_version(self.project, "1.2.4"), [])
+
 
 class UpdateChangelogTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Closes #57

## Summary

- read the package version from `[project].version` with the standard-library TOML parser
- restrict the formatting-preserving write to the `version` assignment inside `[project]`
- add temporary-directory regression coverage for unrelated version keys before and after `[project]` and the missing-version path

## Verification

- `uv run python -m unittest discover -s tests` — 13 tests passed
- `git diff --check` — passed
- mutation check: reinstated the original unscoped read/write logic and ran `PYTHONDONTWRITEBYTECODE=1 uv run python -m unittest tests.test_bump_version.ProjectVersionTests` — all 3 regression tests failed; restored the fix and reran the full suite successfully
