### PR TITLE
[autopilot] skills: add reporting-derived-metrics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "homepage": "https://github.com/wdm0006/python-skills",
-    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation"]
+    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation", "derived-metrics", "thresholds", "statistics", "nullability"]
   },
   "plugins": [
     {
@@ -38,7 +38,17 @@
         "./skills/common/sync-jobs",
         "./skills/common/build-artifacts",
         "./skills/common/reproducing-ci-locally",
-        "./skills/common/cross-surface-changes"
+        "./skills/common/cross-surface-changes",
+        "./skills/common/derived-metrics"
+      ]
+    },
+    {
+      "name": "reporting-derived-metrics",
+      "description": "Compute and report statistics, scores and flags from samples that may be too small to support them - undefined dispersion returned as 0.0 and tripping a minimum threshold, sentinel choice, threshold blocks gated on whether the value was measured, reports that narrate findings from absent data, nullability as a public API change, and broad excepts that disguise a metric bug as a normal result",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/common/derived-metrics"
       ]
     },
     {
@@ -92,7 +102,8 @@
       "source": "./",
       "strict": false,
       "skills": [
-        "./skills/python/llm-features"
+        "./skills/python/llm-features",
+        "./skills/common/derived-metrics"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Or install a language-agnostic bundle:
 
 # Keep user-facing facts consistent across product surfaces
 /plugin install shipping-across-surfaces@dev-skills
+
+# Compute and report statistics, scores, and flags honestly
+/plugin install reporting-derived-metrics@dev-skills
 ```
 
 ### Alternative: Local Installation
@@ -178,6 +181,7 @@ After installation, you can verify the skills are loaded by running:
 | **shipping-build-artifacts** | Make the build step a real gate on what you distribute — build scripts that warn and exit 0 on a missing input, size checks with only an upper bound, hand-maintained file lists that drift from the entrypoints they must cover, committed bundles that go stale when only the source changes, GNU-only shell that aborts on the other OS, and verification that runs against the source tree instead of the artifact | — |
 | **running-resumable-sync-jobs** | Batch/sync jobs that fail honestly — exit codes that report partial failure, checkpoints safe to resume, per-item tolerance vs. fatal abort, unknown-vs-coerced-`0` in aggregated output, bounded per-page retries, dry-runs that mutate in-memory state identically, and compensating reserved quota | — |
 | **reproducing-ci-locally** | Make the local check agree with the runner — deriving the command, paths, marker expression and `env:` from the workflow file rather than the Makefile, running each gate step separately because the first failure hides the rest, pinning the linter version CI resolves (an unpinned formatter that widens file coverage reddens every open PR), building the interpreter and extras the runner builds, fixing divergence in shared config rather than in the YAML, and confirming a run is green instead of explaining a red job away | — |
+| **reporting-derived-metrics** | Compute statistics, scores, and flags from samples that may be too small to support them — undefined dispersion returned as `0.0` and tripping the minimum threshold it is compared against (the least data producing the strongest verdict), `None` vs `0`/`-1`/`NaN` as the sentinel, threshold blocks gated on whether the value was measured, report sentences that narrate findings from absent data, nullability as a public API change, `is None` vs truthiness when `[]`/`0` are real results, and broad excepts that disguise a metric bug as a normal-shaped result | — |
 | **shipping-across-surfaces** | Land a change everywhere the same fact is stated — enumerating the surface inventory (landing copy, structured data, docs, `llms.txt`, changelog plus the version badge repeated in every page's nav, sitemap, README, and the descriptions embedded in code), generating a surface instead of restating it, drift tests that compare against the live registry rather than a second hand-written list, never hand-maintaining a snapshot of a surface another codebase owns, paired producer/consumer PRs for format changes, and keeping overloaded product words apart | — |
 
 ## Plugin Bundles
@@ -207,6 +211,7 @@ After installation, you can verify the skills are loaded by running:
 - **verifying-external-behavior** — integrating a dependency, endpoint, or build backend (probe the exact call, inspect outbound parameters, validate fakes against the real service, skip the dry-run shortcut).
 - **shipping-build-artifacts** — build/package scripts, `dist/` copy steps, committed compiled assets, and release workflows that upload a zip or installer (fail on missing inputs, bound size both ways, rebuild-and-diff committed bundles, verify the artifact before publishing).
 - **reproducing-ci-locally** — running the CI gate on your machine so it agrees with the runner (workflow-derived commands and markers, short-circuiting gate steps, pinned linter versions, the runner's interpreter and extras, confirming green).
+- **reporting-derived-metrics** — scoring and analysis pipelines, z-score/outlier checks, quality and anomaly flags, and metrics rollups (unmeasurable is not zero, gate the threshold on whether the value was measured, never narrate a finding from absent data).
 - **shipping-across-surfaces** — landing a user-facing change everywhere the same fact is stated (surface inventory, generated instead of restated surfaces, drift tests against the live registry, cross-repo format contracts and direction of ownership, overloaded product terms).
 
 Every language bundle includes **keeping-git-repos-clean** — committed-secret and dev-artifact hygiene applies regardless of language.

--- a/skills/common/derived-metrics/SKILL.md
+++ b/skills/common/derived-metrics/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: reporting-derived-metrics
+description: Compute statistics, scores, and flags from samples that may be too small to support them — undefined dispersion returned as 0.0 and tripping a minimum threshold, sentinel choice (None vs 0 vs NaN), threshold blocks gated on "was this measured", reports that narrate findings from absent data, nullability as a public API change, `is None` vs truthiness, and broad excepts that turn a metric bug into a normal-shaped result. Use when writing or reviewing a scoring/analysis pipeline, a z-score or outlier check, a quality or anomaly flag, a metrics rollup, or any function that reduces a list of observations to one number a threshold reads.
+---
+
+# Reporting Derived Metrics
+
+A derived metric is a number computed from a sample and then compared against a
+threshold to produce a flag, a score, or a sentence a user reads as a finding.
+The bugs are almost never in the arithmetic. They are at the two ends: what the
+function returns when the sample is too small to support the statistic, and what
+the flag layer does with that value.
+
+## An undefined statistic is not zero
+
+Dispersion — standard deviation, variance, coefficient of variation, burstiness,
+mean gap between events — needs at least two observations. Ratios and rates need
+a non-zero denominator. The reflex on the short-sample branch is `return 0.0`,
+and that is the worst available answer, because `0` is a real and *extreme* point
+on the same scale the threshold lives on.
+
+Two shapes, both of which turn "no data" into a confident verdict:
+
+- A **minimum threshold** (`variation < 2.5 → suspicious`) is tripped by `0.0`
+  every single time. Any one-segment input is flagged, with a reason string that
+  quotes a measurement that never happened: `low variation (0.00 < 2.5)`.
+- A **z-score against a baseline** (`mean 7.1`, `sd 2.4`) scores `0.0` at
+  `z = -2.96` — a hard outlier. The feature is reported as anomalous precisely
+  when it was not measurable.
+
+Note the direction: the *least* data produces the *strongest* verdict. Make
+unmeasurable its own value.
+
+```python
+# Bad — 0.0 is indistinguishable from "genuinely no variation at all"
+def dispersion(values: list[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    return statistics.stdev(values)
+
+# Good — the caller is forced to decide what "not measurable" means
+def dispersion(values: list[float]) -> float | None:
+    """Sample standard deviation, or None if fewer than two observations."""
+    if len(values) < 2:
+        return None
+    return statistics.stdev(values)
+```
+
+Prefer `None` over the alternatives. `-1` is in-band for anything that can go
+negative. `NaN` is worse than `0.0` in a subtle way: every comparison against it
+is `False`, so it silently produces the mirror bug — a metric that can never trip
+any threshold and never explains why.
+
+## The threshold block needs its own "was this measured" gate
+
+Returning `None` only relocates the bug unless every consumer is updated in the
+same change. `None < 2.5` raises `TypeError`; `(value or 0) < 2.5` faithfully
+reconstructs the original bug. Gate explicitly:
+
+```python
+measured = variation is not None
+
+if measured and variation < cfg.variation_min:
+    flags["suspicious"] = True
+    reasons.append(f"low variation ({variation:.2f} < {cfg.variation_min})")
+elif not measured:
+    reasons.append("variation requires at least two scored segments")
+```
+
+Loops that walk a dict of features must **skip** the unmeasured ones, not
+substitute for them:
+
+```python
+for name, value in features.items():
+    if value is None:
+        continue                     # absent from z_scores and from flags
+    z_scores[name] = (value - baseline[name].mean) / baseline[name].sd
+```
+
+Substituting the baseline mean is the tempting alternative and it is wrong for
+the same reason `0.0` was: it invents a perfectly average observation and reports
+it as one you took.
+
+## Don't narrate findings from data you don't have
+
+The failure mode that survives longest is the report sentence. When every
+per-segment score fails, the aggregate is `None`, and a flag block written as an
+`if/elif` chain will still reach a branch like:
+
+> Low variation (0.00 < 2.5) but acceptable score.
+
+The score was not acceptable. It was absent. Two rules:
+
+- **Every sentence in a report must name a value that was actually measured.**
+  If a branch can be reached with its subject unmeasured, it is not a finding,
+  it is a template.
+- **An empty `reasons` list is itself a claim.** A result with no reasons reads
+  as "nothing wrong". When a metric could not be computed, say so explicitly
+  ("requires at least two scored segments") rather than emitting nothing.
+
+## Nullability is a public API change, not an implementation detail
+
+The moment a metric can be `None`, the field is `float | null` for everyone
+downstream. That is a versioned surface: the response schema, the serializer, the
+docs table, the renderer that calls `f"{value:.2f}"`, the rollup that calls
+`sum()` over the column, and every consumer's tests. Land them together — see
+**shipping-across-surfaces**. Picking the nullable type up front, before anything
+consumes the field, is much cheaper than widening it later.
+
+## Check `is None`, never truthiness
+
+Once "unavailable" is representable, the availability check has to be exact.
+`[]` from a genuinely empty collection, `0` from a real count, and `0.0` from a
+real measurement are all successful results:
+
+```python
+# Bad — fires the "data unavailable" warning on a healthy zero
+if not referrers:
+    incomplete.append(repo)
+
+# Good
+if referrers is None:
+    incomplete.append(repo)
+```
+
+The truthiness version is especially quiet because it usually ships green: test
+fixtures that pass an empty list to represent "nothing to report" start
+triggering the unavailable path, and nothing asserts that they don't. The same
+applies to `payload.get("count", 0)`, which turns a missing key into a confident
+zero.
+
+## Recheck the guards a new gate makes redundant
+
+Adding the `measured` gate changes what the surrounding conditions can be. A
+measured dispersion implies at least two finite per-segment scores, which implies
+the aggregate is finite — so an `isfinite(aggregate)` check added *inside* the
+gated branch is inert code. Inert defensive checks are not free: they cost review
+attention and advertise a failure mode that cannot occur. After adding a gate,
+ask which existing conditions it now implies, and delete those.
+
+The converse also holds: **a `None` check is not a type check.** A non-numeric
+value still reaches `(value - mean)` and raises `TypeError`. If arbitrary values
+can reach the metric layer, validate the type at the boundary rather than adding
+guards one exception at a time.
+
+## A broad `except` turns a metric bug into a normal-shaped result
+
+Analysis entry points are often wrapped so a caller never sees a traceback:
+
+```python
+except Exception as e:
+    return {"error": f"Analysis failed: {e}", "features": {}, "flags": {"suspicious": False}}
+```
+
+This shape is genuinely useful — it keeps a protocol boundary well-behaved — and
+it is exactly why these bugs live for months. A `KeyError` from a mis-wired
+config key, a `TypeError` from an unguarded feature value, and a real analysis
+all return the same shape with default flags. Any test that asserts only on the
+result's *shape* stays green through all three.
+
+So: assert `"error" not in result` in every test that exercises the metric path,
+and log the swallowed exception with a traceback rather than only folding its
+`str()` into the payload.
+
+## Testing
+
+- **Fixture with a single observation**, plus a separate one with zero. Assert
+  three things, not one: the metric is `None`, the flag is `False`, and the
+  reason string explains why it was not measurable.
+- **Choose fixture values where the buggy and fixed versions disagree.** Any
+  two-or-more-observation sample returns the same number either way, so a
+  "normal" fixture cannot see this bug at all.
+- **Mutate in both directions.** Restore `return 0.0` — the single-observation
+  flag test must fail. Separately, delete the `measured` gate while keeping the
+  `None` return — the same test must fail again, for a different reason. One
+  regression test that only catches one of the two leaves the other shippable.
+- **Know which assertion each mutation trips.** Deleting the `None`-skip in a
+  z-score loop fails the test on `"error" not in result` (the `TypeError` was
+  swallowed into the error shape), not on the flag assertion. That is still a
+  useful mutation signal, but read it as "the guard is load-bearing at a
+  different layer" rather than assuming the flag logic is covered.
+- **Test the all-inputs-failed path** end to end and assert that no reason
+  mentions an acceptable or in-range value.
+
+## Checklist
+
+- [ ] Every statistic requiring N observations returns `None` below N, not `0.0`
+- [ ] Sentinel is `None` — not `0`, `-1`, or `NaN` (which never trips anything)
+- [ ] Threshold blocks gate on "measured"; unmeasured can never set a flag
+- [ ] Feature loops skip `None` rather than substituting a mean or a default
+- [ ] Every reason/finding string names a value that was actually measured
+- [ ] Unmeasurable emits an explicit reason; `reasons == []` never means "absent"
+- [ ] Nullable metric landed across schema, serializer, renderer, rollup, docs
+- [ ] Availability checked with `is None`; `[]`/`0`/`0.0` treated as real results
+- [ ] Guards made redundant by a new gate deleted; type validated at the boundary
+- [ ] Metric tests assert `"error" not in result`, not just the result's shape
+- [ ] Single- and zero-observation fixtures assert value, flag, and reason
+- [ ] Mutation-tested both ways: restore the `0.0` return, and drop the gate
+
+Related: **running-resumable-sync-jobs** for the same unknown-vs-zero distinction
+in fetched and aggregated data, **building-llm-backed-features** for why an empty
+evaluator set is not a clean pass, and **testing-python-libraries** for proving a
+regression test can actually fail.


### PR DESCRIPTION
## What changed

New language-agnostic skill `skills/common/derived-metrics/SKILL.md` (`reporting-derived-metrics`), registered in the `python-library-complete` and `python-llm-features` bundles plus a standalone bundle, with the marketplace version bumped and the README install list, skills table, and bundle list updated.

## The pattern that motivated it

A statistic that needs at least two observations — standard deviation, variance, burstiness, coefficient of variation, mean gap between events — is written to `return 0.0` on the short-sample branch. That value is then compared against a *minimum* threshold, or z-scored against a baseline mean. Both land on "anomalous": `0.0` trips `< threshold` every time, and `0.0` against a baseline of mean 7.1 / sd 2.4 scores z = −2.96. The least data produces the strongest verdict, and the report quotes a measurement that never happened (`low variation (0.00 < 2.5)`).

The same shape recurred at every layer around it, which is what makes it worth a skill rather than a bullet:

- Returning `None` only relocates the bug — `(value or 0) < threshold` faithfully reconstructs it, and a z-score loop that substitutes the baseline mean invents a perfectly average observation.
- An `if/elif` flag chain reaches a "but acceptable score" branch when the score was absent, not acceptable; an empty `reasons` list reads as "nothing wrong".
- Once the metric is nullable it is a `float | null` public field — schema, serializer, renderer, rollup, docs.
- The availability check then has to be `is None`, because `[]`, `0`, and `0.0` are all real results; a truthiness check fires the "unavailable" path on healthy data.
- A broad `except Exception` around the analysis returns the same error-shaped payload with default flags for a wiring bug, a `TypeError`, and a real run — so any test asserting only on result shape stays green.

## How a reader benefits

The testing section is the part that is hard to reinvent: a normal multi-observation fixture cannot see this bug at all, so it names the single- and zero-observation fixtures, the three assertions each needs (value, flag, reason), and the two mutations that must each fail the test — restoring `return 0.0`, and dropping the measured-gate while keeping the `None` return. It also flags that deleting the `None`-skip in a z-score loop fails on `"error" not in result` rather than the flag assertion, so the signal is read at the right layer.

Cross-referenced with the existing sync-jobs, llm-features, cross-surface-changes, and testing skills rather than duplicating them.