### PR TITLE
[autopilot] skills: tell "unavailable" from "zero" in the artifact, not just the console

### DIFF
--- a/skills/common/sync-jobs/SKILL.md
+++ b/skills/common/sync-jobs/SKILL.md
@@ -154,6 +154,30 @@ but a `None` from fetchers B and C is silently coerced to 0 and dropped from the
 aggregate, the trailing "skipped: M" line under-reports and the totals are wrong
 in a direction no reader can detect.
 
+**Compare against the sentinel, never truthiness.** Every healthy value in this
+position is falsy: a referrer list is `[]` for a target that genuinely has none,
+a counter is `{"count": 0}` for a quiet period. So `if not clones:` fires the
+incomplete-data warning on complete data — and it quietly repurposes every
+empty-result fixture already in your suite, which keeps passing while now
+exercising the failure branch. The distinction you are drawing is *unmeasured*
+vs. *measured zero*, and only `is None` draws it.
+
+```python
+if not referrers:            # Bad — a target with no referrers is not a failure
+if referrers is None:        # Good
+```
+
+**Put the signal in the artifact, not only on the console.** The common half-fix
+names the failed targets in a warning printed after the totals and leaves the
+coerced `0` in the exported file. That serves the operator watching the run and
+nobody else: a downstream dashboard, a spreadsheet, or a diff against yesterday's
+export sees a confident zero with no way to tell it from a quiet period, and the
+row still counts as *analyzed* in the run's own summary. If you must keep the
+coerced value for schema compatibility, ship the companion signal alongside it —
+a `clones_available` column, an `incomplete` block in a manifest, a non-zero exit
+— and be explicit in the PR that the file alone remains ambiguous. A warning on
+stderr is not a channel; it is a courtesy.
+
 **Cross-check totals against detail when the source gives you both.** If a page
 publishes "1,759 contributions in 2024" and your parser extracts zero rows, that
 is a parse failure, not an empty year. A positive summary with an empty detail
@@ -288,6 +312,14 @@ Three details that make refunds safe:
   not select the branch you think.
 - **A missing cap makes the suite hang, not fail.** Run the mutated suite under
   an external timeout; no output within N seconds *is* the reproduction.
+- **Fail one sub-fetch while the primary one succeeds.** Undercounting only
+  appears when part of an item's data lands and part doesn't. Serving a plain
+  non-rate-limit `403`/`404` for just the secondary URL takes the fetcher's skip
+  branch with no retry and no clock to patch — much lighter than driving the
+  persistent-rate-limit path. Pair it with a control test asserting a fully
+  successful run emits *no* incomplete-data warning: the two plausible wrong
+  implementations are dropping the tracking and warning unconditionally, and
+  neither test catches both.
 - **Test the resume, not just the run.** Fail item K, then run again against the
   same state and assert the remaining items are attempted and the completed ones
   are not re-applied. A single-run test cannot see either checkpoint bug.
@@ -301,6 +333,8 @@ Three details that make refunds safe:
 - [ ] Skip/dead branches verified reachable (grep the handler's other callers)
 - [ ] Output written incrementally, or the cheap pass persisted before enrichment
 - [ ] Failed fetches are `None`/absent in the artifact, never a coerced `0`
+- [ ] Availability checked with `is None`; `[]` and `0` stay healthy values
+- [ ] A reader of the exported file alone can tell "unavailable" from "zero"
 - [ ] Summary-vs-detail contradiction raises instead of returning empty
 - [ ] Every retry loop is bounded, counted per unit, and reset after a success
 - [ ] The "who waits" contract is documented and no caller double-sleeps


### PR DESCRIPTION
Sharpens `skills/common/sync-jobs/SKILL.md`'s "Distinguish zero from couldn't fetch" section with three things learned while fixing this class of bug for real. One file, +34 lines, no new skill.

## What changed

- **Compare against the sentinel, never truthiness.** Added the trap the existing `is None` example demonstrated but never explained: every healthy value in this position is falsy (`[]` for a target that genuinely has no referrers, `{"count": 0}` for a quiet period), so an `if not x:` availability guard fires the incomplete-data warning on complete data — and silently repurposes the empty-result fixtures already in the suite, which keep passing while now exercising the failure branch.
- **Put the signal in the artifact, not only on the console.** New paragraph on the half-fix that names failed targets in a warning printed after the totals while leaving the coerced `0` in the exported file. That serves the operator watching the run and nobody else: a downstream dashboard or a diff against yesterday's export still sees a confident zero, and the row still counts as *analyzed*. If the coerced value has to stay for schema compatibility, ship a companion column/manifest flag/non-zero exit and say plainly that the file alone remains ambiguous.
- **Testing bullet + two checklist lines.** The cheapest way to reproduce partial-item undercounting is a plain non-rate-limit `403` for just the secondary URL — it takes the fetcher's skip branch with no retry and no clock to patch, far lighter than driving a persistent rate limit. Paired with the control test asserting a fully successful run warns *nothing*, since the two plausible wrong implementations (dropped tracking, unconditional warning) are each caught by only one of the two tests.

## Pattern that motivated it

Across several aggregation jobs, the same fix kept landing halfway: the fetcher was taught to return `None` on failure and the run was taught to print which targets were incomplete, but the exported file kept the `0` fill and the "skipped" count kept tracking only the primary fetch. Every consumer that reads the artifact instead of watching the terminal was still silently undercounting. The adjacent bug was the guard itself — written as a truthiness check, it flagged genuinely-empty results as failures, which the existing empty-result tests could not catch because they were rewritten in meaning rather than broken.

## Benefit

A reader following the skill now gets the discrimination rule (`is None`, because zero and empty are load-bearing values), the completeness rule (the artifact is the only channel a downstream reader has), and a cheap, clock-free recipe for testing the partial-failure shape plus the control test that keeps the warning from becoming unconditional.