### PR TITLE
[autopilot] skills: keep MCP tools responsive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.15.0",
+    "version": "2.16.0",
     "homepage": "https://github.com/wdm0006/python-skills",
-    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation", "derived-metrics", "thresholds", "statistics", "nullability"]
+    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation", "derived-metrics", "thresholds", "statistics", "nullability", "event-loop", "concurrency"]
   },
   "plugins": [
     {
@@ -108,7 +108,7 @@
     },
     {
       "name": "python-mcp-servers",
-      "description": "Build robust Python MCP servers - tool error contracts, subprocess wrapping, single-file vs packaged distribution, and global-state-free testing",
+      "description": "Build robust Python MCP servers - tool error contracts, event-loop-safe blocking work, subprocess wrapping, single-file vs packaged distribution, and global-state-free testing",
       "source": "./",
       "strict": false,
       "skills": [

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ After installation, you can verify the skills are loaded by running:
 | **building-python-communities** | CONTRIBUTING.md, issue templates, PR templates, GitHub automation | [Building Engaging Community](https://mcginniscommawill.com/posts/2025-01-22-building-engaging-community/), [Inner Source Introduction](https://mcginniscommawill.com/posts/2025-02-11-inner-source-introduction/), [From Silos to Shared Libraries](https://mcginniscommawill.com/posts/2025-02-18-silos-to-shared-libraries/) |
 | **reviewing-python-libraries** | Comprehensive library reviews across all quality dimensions | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
 | **building-python-web-apps** | Opinionated reference architecture for production web apps — FastAPI, async SQLAlchemy/Postgres, centralized bcrypt password limits, fail-closed distributed auth rate limiting, Stripe billing, Jinja or SPA frontends, and Dockerized deployment via Terraform | Production web app patterns |
-| **building-python-mcp-servers** | Robust Python MCP servers with FastMCP — tool design, error contracts, CLI/subprocess wrapping, single-file vs packaged distribution, testing, and prompt-injection awareness | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
+| **building-python-mcp-servers** | Robust Python MCP servers with FastMCP — tool design, error contracts, event-loop-safe blocking work, CLI/subprocess wrapping, single-file vs packaged distribution, testing, and prompt-injection awareness | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
 | **building-llm-backed-features** | Application features on top of an LLM API — prompt surfaces that drift apart, filtered evaluator sets that cannot silently become clean passes, config wiring validated at boot, live-model tests kept out of CI, stochastic accuracy evaluation, and output that doesn't over-claim | [Guide to Python Libraries](https://mcginniscommawill.com/guides/python-library-development/) |
 
 ### Go
@@ -202,7 +202,7 @@ After installation, you can verify the skills are loaded by running:
 - **python-library-distribution** — packaging, release management, CLI development, build-artifact shipping.
 - **python-library-quality** — security audit, performance, API design, untrusted-content rendering, external-behavior verification, git hygiene.
 - **python-web-app** — web-app architecture (FastAPI, async SQLAlchemy, Stripe, Docker/Terraform deployment) + untrusted-content rendering.
-- **python-mcp-servers** — MCP servers (FastMCP tool design, error contracts, packaging, testing, prompt-injection awareness).
+- **python-mcp-servers** — MCP servers (FastMCP tool design, error contracts, event-loop-safe blocking work, packaging, testing, prompt-injection awareness).
 - **python-llm-features** — LLM-backed features (prompt surfaces, structured outputs, context budgeting, model config wiring, accuracy evaluation).
 
 ### Language-agnostic

--- a/skills/python/mcp-servers/SKILL.md
+++ b/skills/python/mcp-servers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: building-python-mcp-servers
-description: Builds robust Python MCP (Model Context Protocol) servers with FastMCP — tool design, error contracts, subprocess/CLI wrapping, single-file vs packaged distribution, global-state-free testing, and prompt-injection awareness. Use when writing an MCP server, exposing a tool or CLI to an LLM client, debugging tool registration/packaging, or testing MCP tools.
+description: Builds robust Python MCP (Model Context Protocol) servers with FastMCP — tool design, error contracts, event-loop-safe blocking work, subprocess/CLI wrapping, single-file vs packaged distribution, global-state-free testing, and prompt-injection awareness. Use when writing an MCP server, exposing a tool or CLI to an LLM client, debugging tool registration/packaging, or testing MCP tools.
 ---
 
 # Building Python MCP Servers
@@ -118,6 +118,50 @@ This also avoids **double registration**: a module-level "create all tools" loop
 run directly (`uv run server.py`, as Claude Desktop does) versus via a console
 entry point. Register in exactly one place.
 
+## Keep blocking work off the protocol event loop
+
+Do not assume a framework moves synchronous tool functions to a worker thread.
+Some FastMCP runtimes invoke them inline on the protocol event loop. A SQLite
+query, filesystem walk, dependency traversal, or synchronous HTTP call that takes
+five seconds can therefore block pings and every unrelated request for the same
+five seconds.
+
+Make the tool async and move only the blocking boundary to a thread:
+
+```python
+import asyncio
+
+@mcp.tool()
+async def find_dependents(item_id: int) -> dict:
+    rows = await asyncio.to_thread(repository.find_dependents, item_id)
+    return {"items": [row.to_dict() for row in rows]}
+```
+
+Keep connection ownership in mind. Do not create a SQLite connection on the
+event-loop thread and hand that connection to the worker. Open and close it
+inside `repository.find_dependents`, or use a pool/driver whose concurrency
+contract explicitly permits the handoff. A thread wrapper around a shared,
+thread-affine connection merely trades event-loop starvation for intermittent
+database errors.
+
+Test responsiveness, not just the slow tool's result. Start a deliberately
+blocked repository call, invoke a lightweight tool (or protocol ping) before
+releasing it, and require the lightweight request to finish first:
+
+```python
+slow = asyncio.create_task(call_tool("find_dependents", {"item_id": 42}))
+await entered_worker.wait()
+
+healthy = await asyncio.wait_for(call_tool("health", {}), timeout=0.2)
+assert healthy == {"ok": True}
+
+release_worker.set()
+await slow
+```
+
+A timing assertion on the slow call alone cannot detect event-loop starvation;
+the regression is that independent protocol traffic stops making progress.
+
 ## Sampling is an optional client capability — contain failures in the tool
 
 `ctx.sample(...)` is not guaranteed to work just because the tool itself was
@@ -205,6 +249,8 @@ Subprocess:
 Structure:
 - [ ] No module-level CLI parsing / global state
 - [ ] Tools registered in exactly one place
+- [ ] Blocking database/filesystem/network work moved off the protocol event loop
+- [ ] Concurrency test proves a lightweight request completes while a slow tool is blocked
 
 Distribution & tests:
 - [ ] No server.py / server/ name collision; build includes the whole package


### PR DESCRIPTION
## What changed

- sharpened the Python MCP server skill with an explicit rule for moving blocking database, filesystem, and synchronous network work off the protocol event loop
- added connection-ownership guidance for thread-affine database clients
- added a concurrency regression-test pattern that proves lightweight protocol traffic remains responsive while a slow tool is blocked
- updated the existing bundle metadata and README description

## Motivation

The motivating cross-project pattern is that a synchronous database-backed MCP tool may run inline on the protocol event loop under some runtimes. A slow backlog scan or dependency traversal can then block pings and unrelated requests until it returns. Tests that only assert the slow tool's eventual result do not detect this loss of responsiveness.

Readers now get a concrete implementation boundary and a test that observes the actual concurrency invariant.

## Validation

- `python3 -m json.tool .claude-plugin/marketplace.json`
- `git diff --check`
- `uv run --with pytest pytest -q` — 15 passed, 35 subtests passed
