### PR TITLE
release-management: report when --changelog makes no changelog entry

### DIFF
--- a/skills/python/release-management/scripts/bump_version.py
+++ b/skills/python/release-management/scripts/bump_version.py
@@ -14,8 +14,24 @@ import sys
 import tomllib
 from datetime import date
 from pathlib import Path
+from typing import Literal
 
 BUMP_TYPES = ("major", "minor", "patch")
+
+# Outcomes of a --changelog request. Only CHANGELOG_ALREADY_RELEASED is an
+# intentional no-op; the other two mean the caller asked for an entry that
+# could not be written.
+CHANGELOG_UPDATED = "updated"
+CHANGELOG_ALREADY_RELEASED = "already-released"
+CHANGELOG_MISSING = "no-changelog"
+CHANGELOG_NO_UNRELEASED = "no-unreleased-heading"
+
+ChangelogOutcome = Literal[
+    "updated",
+    "already-released",
+    "no-changelog",
+    "no-unreleased-heading",
+]
 
 
 def get_current_version(project_path: Path) -> str | None:
@@ -136,18 +152,18 @@ def update_changelog(
     project_path: Path,
     new_version: str,
     dry_run: bool = False,
-) -> bool:
+) -> ChangelogOutcome:
     """Insert a new release heading under the [Unreleased] section of the changelog."""
     changelog = project_path / "CHANGELOG.md"
     if not changelog.exists():
-        return False
+        return CHANGELOG_MISSING
 
     content = changelog.read_text()
 
     # Already released: leave the file untouched so retried releases don't
     # insert a second heading for the same version.
     if re.search(rf'(?m)^##\s*\[?{re.escape(new_version)}\]?(?![\w.\-])', content):
-        return False
+        return CHANGELOG_ALREADY_RELEASED
 
     today = date.today().isoformat()
 
@@ -161,12 +177,12 @@ def update_changelog(
     )
 
     if content == new_content:
-        return False
+        return CHANGELOG_NO_UNRELEASED
 
     if not dry_run:
         changelog.write_text(new_content)
 
-    return True
+    return CHANGELOG_UPDATED
 
 
 def main():
@@ -241,8 +257,19 @@ def main():
         print(f"  - {f}")
 
     if args.changelog:
-        if update_changelog(project_path, new_version, args.dry_run):
-            print(f"  - {project_path / 'CHANGELOG.md'}")
+        changelog = project_path / "CHANGELOG.md"
+        outcome = update_changelog(project_path, new_version, args.dry_run)
+        if outcome == CHANGELOG_UPDATED:
+            print(f"  - {changelog}")
+        elif outcome == CHANGELOG_ALREADY_RELEASED:
+            print(f"  - {changelog}: already has a {new_version} heading, left unchanged")
+        elif outcome == CHANGELOG_MISSING:
+            print(f"  ! Warning: no changelog entry written - {changelog} does not exist")
+        else:
+            print(
+                f"  ! Warning: no changelog entry written - {changelog} has no "
+                "'## [Unreleased]' heading to insert the release under"
+            )
 
     if not updated:
         print("  No files updated")

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,4 +1,6 @@
+import contextlib
 import importlib.util
+import io
 import re
 import sys
 import tempfile
@@ -93,8 +95,11 @@ class UpdateChangelogTests(unittest.TestCase):
             self.changelog.read_text(),
         )
 
+    def update(self, version, dry_run=False):
+        return BUMP_VERSION.update_changelog(self.project, version, dry_run)
+
     def test_first_update_inserts_one_heading_below_unreleased(self):
-        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_UPDATED)
 
         self.assertEqual(len(self.headings("1.2.3")), 1)
         lines = self.changelog.read_text().splitlines()
@@ -102,34 +107,128 @@ class UpdateChangelogTests(unittest.TestCase):
         self.assertEqual(lines[unreleased + 1], "")
         self.assertRegex(lines[unreleased + 2], r'^## \[1\.2\.3\] - \d{4}-\d{2}-\d{2}$')
 
-    def test_repeated_update_is_a_no_op(self):
-        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+    def test_repeated_update_reports_already_released(self):
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_UPDATED)
         after_first = self.changelog.read_bytes()
 
-        self.assertFalse(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_ALREADY_RELEASED)
 
         self.assertEqual(self.changelog.read_bytes(), after_first)
         self.assertEqual(len(self.headings("1.2.3")), 1)
 
+    def test_missing_changelog_reports_no_changelog(self):
+        self.changelog.unlink()
+
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_MISSING)
+
+    def test_changelog_without_unreleased_heading_is_left_untouched(self):
+        self.changelog.write_text(CHANGELOG.replace("## [Unreleased]\n", "", 1))
+        before = self.changelog.read_bytes()
+
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_NO_UNRELEASED)
+
+        self.assertEqual(self.changelog.read_bytes(), before)
+        self.assertEqual(self.headings("1.2.3"), [])
+
+    def test_dry_run_reports_the_outcome_without_writing(self):
+        before = self.changelog.read_bytes()
+
+        self.assertEqual(self.update("1.2.3", dry_run=True), BUMP_VERSION.CHANGELOG_UPDATED)
+
+        self.assertEqual(self.changelog.read_bytes(), before)
+        self.assertEqual(self.headings("1.2.3"), [])
+
     def test_version_mentioned_only_in_prose_or_links_is_not_a_release_heading(self):
         # The fixture already cites 1.2.3 in release notes and in a link
         # reference, so the first insertion must still happen.
-        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_UPDATED)
         self.assertEqual(len(self.headings("1.2.3")), 1)
 
     def test_other_versions_are_still_inserted(self):
-        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
-        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.3.0"))
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_UPDATED)
+        self.assertEqual(self.update("1.3.0"), BUMP_VERSION.CHANGELOG_UPDATED)
 
         self.assertEqual(len(self.headings("1.2.3")), 1)
         self.assertEqual(len(self.headings("1.3.0")), 1)
 
     def test_existing_heading_for_a_longer_version_does_not_block_a_prefix(self):
-        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.30"))
-        self.assertTrue(BUMP_VERSION.update_changelog(self.project, "1.2.3"))
+        self.assertEqual(self.update("1.2.30"), BUMP_VERSION.CHANGELOG_UPDATED)
+        self.assertEqual(self.update("1.2.3"), BUMP_VERSION.CHANGELOG_UPDATED)
 
         self.assertEqual(len(self.headings("1.2.3")), 1)
         self.assertEqual(len(self.headings("1.2.30")), 1)
+
+
+class ChangelogReportingTests(unittest.TestCase):
+    """--changelog must say what happened instead of silently doing nothing."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        # main() resolves --project, so match that here (/var -> /private/var).
+        self.project = Path(self.temp_dir.name).resolve()
+        (self.project / "pyproject.toml").write_text(PYPROJECT)
+        self.changelog = self.project / "CHANGELOG.md"
+        self.changelog.write_text(CHANGELOG)
+
+    def run_main(self, spec="patch", *extra_args):
+        argv = ["bump_version.py", spec, "--project", str(self.project), "--changelog"]
+        argv.extend(extra_args)
+        out = io.StringIO()
+        original_argv = sys.argv
+        sys.argv = argv
+        try:
+            with contextlib.redirect_stdout(out):
+                BUMP_VERSION.main()
+        finally:
+            sys.argv = original_argv
+        return out.getvalue()
+
+    def test_updated_changelog_is_listed(self):
+        output = self.run_main()
+
+        self.assertIn(f"  - {self.changelog}\n", output)
+        self.assertNotIn("Warning", output)
+
+    def test_missing_unreleased_heading_is_reported(self):
+        self.changelog.write_text(CHANGELOG.replace("## [Unreleased]\n", "", 1))
+        before = self.changelog.read_bytes()
+
+        output = self.run_main()
+
+        self.assertIn("Warning", output)
+        self.assertIn("## [Unreleased]", output)
+        self.assertEqual(self.changelog.read_bytes(), before)
+
+    def test_missing_changelog_file_is_reported(self):
+        self.changelog.unlink()
+
+        output = self.run_main()
+
+        self.assertIn("Warning", output)
+        self.assertIn(str(self.changelog), output)
+        self.assertFalse(self.changelog.exists())
+
+    def test_already_released_version_is_reported(self):
+        output = self.run_main()
+        self.assertIn(f"  - {self.changelog}\n", output)
+        after_first = self.changelog.read_bytes()
+
+        output = self.run_main("1.2.4")
+
+        self.assertIn("already has a 1.2.4 heading", output)
+        self.assertNotIn("Warning", output)
+        self.assertEqual(self.changelog.read_bytes(), after_first)
+
+    def test_dry_run_reports_without_writing(self):
+        self.changelog.write_text(CHANGELOG.replace("## [Unreleased]\n", "", 1))
+        before = self.changelog.read_bytes()
+
+        output = self.run_main("patch", "--dry-run")
+
+        self.assertIn("Warning", output)
+        self.assertIn("## [Unreleased]", output)
+        self.assertEqual(self.changelog.read_bytes(), before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #79

`update_changelog` returned a bare `False` from three different situations and `main()` collapsed all of them into "print nothing":

1. `CHANGELOG.md` does not exist.
2. A heading for this version already exists — the intentional idempotency guard from #62.
3. No `## [Unreleased]` heading is present, so the insertion `re.sub` matches nothing.

Only (2) is a legitimate no-op. In cases (1) and (3) the script printed the git commit/tag/push next steps with nothing to indicate the changelog had been skipped, so a release could ship with the version bumped everywhere except the changelog.

## What changed

- `update_changelog` returns a discriminated outcome — `"updated"`, `"already-released"`, `"no-changelog"`, `"no-unreleased-heading"` — exposed as module constants (`CHANGELOG_UPDATED`, `CHANGELOG_ALREADY_RELEASED`, `CHANGELOG_MISSING`, `CHANGELOG_NO_UNRELEASED`) with a `Literal` alias for the return annotation. Stdlib only, and easy to assert on.
- `main()` prints the file path on `"updated"`, an informational "already has a X.Y.Z heading, left unchanged" line on `"already-released"`, and a warning naming the reason on the other two — for the missing-heading case it says a `## [Unreleased]` heading is required, which is the Keep a Changelog shape `SKILL.md` documents.
- Exit code stays 0 in every case; this is a warning, not a failure.
- The insertion logic and the #62 idempotency guard are byte-for-byte unchanged.
- `tests/test_bump_version.py` gains a case per outcome plus a `ChangelogReportingTests` class that drives `main()` and asserts on the console output. The pre-existing `assertTrue`/`assertFalse` cases now assert the specific outcome value.

## Verification

`uv run python -m unittest discover -s tests` — **23 tests, OK** (was 15).

End-to-end against a scratch project (`uv run --no-project --python 3.12`), all four cases, exit 0 throughout:

| case | output line | file |
|---|---|---|
| no `CHANGELOG.md` | `! Warning: no changelog entry written - .../CHANGELOG.md does not exist` | — |
| no `## [Unreleased]` | `! Warning: no changelog entry written - .../CHANGELOG.md has no '## [Unreleased]' heading to insert the release under` | untouched |
| success | `- .../CHANGELOG.md` | exactly one `## [1.2.4] - 2026-08-19` under `[Unreleased]` |
| already released | `- .../CHANGELOG.md: already has a 1.2.4 heading, left unchanged` | untouched, still one heading |

`--dry-run --changelog` reports the same outcome and writes nothing (covered by two tests, and confirmed by hand on the already-released case above).

### Mutation check

Collapsed the outcomes back to a bare `bool` (four `return CHANGELOG_*` → `True`/`False`, `main()`'s block back to `if update_changelog(...): print(...)`), cleared `__pycache__`, and re-ran: **12 of 23 tests failed.** That includes all four of the console-output tests that carry the new behaviour — `test_missing_unreleased_heading_is_reported`, `test_missing_changelog_file_is_reported`, `test_already_released_version_is_reported`, `test_dry_run_reports_without_writing`. `test_updated_changelog_is_listed` correctly still passed, since the success path's output is unchanged. Restored the file and re-ran: 23 tests, OK, and `git status` clean.

### Lint

`uvx ruff check` (repo has no ruff config) on the two touched files gives the same pre-existing findings as `main` — `EXE001`, `DTZ011`, `I001` — minus `SIM102`, which drops out because the nested `if args.changelog: if update_changelog(...)` is gone. No new findings.