### PR TITLE
security-audit: fail security_scan.py when a requested scanner could not run

### DIFF
--- a/skills/python/security-audit/CI_SECURITY.md
+++ b/skills/python/security-audit/CI_SECURITY.md
@@ -56,6 +56,8 @@ Each step exits non-zero on findings, which fails the job. `bandit -ll` gates on
 
 Instead of four separate steps, run all scanners through the script this skill ships. It aggregates findings and exits non-zero when any is blocking (HIGH/CRITICAL bandit, any vulnerable dependency, ERROR-level semgrep, or any secret), so a single step gates the job.
 
+Exit codes: `1` for a blocking finding, `2` when a requested scanner could not run at all (missing from `PATH`, failed to launch, or timed out), `0` only when every requested scanner ran and nothing blocking was found. A scanner that never ran leaves its class of finding unchecked, so it fails the gate rather than reporting a clean audit; the console summary and the `--output` JSON both name the scanners that did not run.
+
 ```yaml
       - name: Security scan
         run: uv run python scripts/security_scan.py . --output security-report.json
@@ -68,7 +70,7 @@ Instead of four separate steps, run all scanners through the script this skill s
           path: security-report.json
 ```
 
-Skip a scanner that does not apply with `--skip` (choices: `bandit`, `pip-audit`, `semgrep`, `secrets`); for example `--skip semgrep` while tuning rules. The script reports a missing scanner as an error for that tool rather than crashing, so install all four via `uv tool install` first. `if: always()` uploads the JSON even when the scan fails, so findings are inspectable from the run.
+Skip a scanner that does not apply with `--skip` (choices: `bandit`, `pip-audit`, `semgrep`, `secrets`); for example `--skip semgrep` while tuning rules. A skipped scanner is not counted as a failure, so use `--skip` for a scanner you deliberately do not want. The script reports a missing scanner as an error for that tool rather than crashing, and exits `2`, so install all four via `uv tool install` first. `--allow-scanner-failure` restores the tolerant exit `0` for callers that genuinely want it. `if: always()` uploads the JSON even when the scan fails, so findings are inspectable from the run.
 
 ## Pre-commit Hook for detect-secrets
 

--- a/skills/python/security-audit/SKILL.md
+++ b/skills/python/security-audit/SKILL.md
@@ -8,8 +8,12 @@ description: Audits Python libraries for security vulnerabilities using Bandit, 
 ## Quick Start
 
 ```bash
-# Run all four scanners; exits non-zero on any blocking finding (gates CI):
+# Run all four scanners (gates CI): exit 1 on a blocking finding, exit 2 when a
+# requested scanner could not run, exit 0 only when every scanner ran clean:
 uv run python scripts/security_scan.py .
+
+# Tolerate scanners that are missing or hung (restores exit 0 in that case):
+uv run python scripts/security_scan.py . --allow-scanner-failure
 
 # Or individually:
 uvx bandit -r src/ -ll                       # High-severity static analysis
@@ -114,7 +118,7 @@ not make the security test pass vacuously.
 ```
 
 For detailed patterns, see:
-- **scripts/security_scan.py** — runs all four scanners and exits non-zero on blocking findings (`uv run python scripts/security_scan.py .`)
+- **scripts/security_scan.py** — runs all four scanners and exits non-zero on blocking findings (exit 1) or on a requested scanner that could not run (exit 2, opt out with `--allow-scanner-failure`) (`uv run python scripts/security_scan.py .`)
 - **[VULNERABILITIES.md](VULNERABILITIES.md)** - Vulnerability classes with vulnerable→fixed pairs
 - **[CI_SECURITY.md](CI_SECURITY.md)** - Complete CI workflow, pre-commit, Dependabot, triage
 

--- a/skills/python/security-audit/scripts/security_scan.py
+++ b/skills/python/security-audit/scripts/security_scan.py
@@ -5,6 +5,11 @@ Runs Bandit (static analysis), pip-audit (dependency CVEs), Semgrep (pattern-bas
 SAST), and detect-secrets (hardcoded credentials), aggregates the findings, and
 exits non-zero when any blocking issue is found so it can gate CI.
 
+A scanner that could not run at all is a gate failure too: exit 1 on blocking
+findings, exit 2 when a requested scanner did not run, and 0 only when every
+requested scanner ran clean. Pass --allow-scanner-failure to tolerate scanners
+that could not run.
+
 Usage:
     uv run python scripts/security_scan.py /path/to/project
     uv run python scripts/security_scan.py . --output report.json
@@ -156,6 +161,11 @@ def _describe(finding) -> str:
     return str(finding)
 
 
+def failed_scanners(results: list[ScanResult]) -> list[str]:
+    """Name the requested scanners that could not run (missing, hung, or crashed)."""
+    return [result.tool for result in results if not result.success]
+
+
 def format_report(results: list[ScanResult]) -> str:
     """Format scan results as a readable report."""
     lines = ["=" * 60, "Security Scan Report", "=" * 60, ""]
@@ -183,6 +193,9 @@ def format_report(results: list[ScanResult]) -> str:
 
     lines.append("=" * 60)
     lines.append(f"Total findings: {total_findings} ({total_blocking} blocking)")
+    failed = failed_scanners(results)
+    if failed:
+        lines.append(f"Scanners that did not run: {len(failed)} ({', '.join(failed)})")
     lines.append("=" * 60)
 
     return "\n".join(lines)
@@ -208,6 +221,11 @@ def main():
         choices=["bandit", "pip-audit", "semgrep", "secrets"],
         default=[],
         help="Skip specific scanners",
+    )
+    parser.add_argument(
+        "--allow-scanner-failure",
+        action="store_true",
+        help="Exit 0 when a requested scanner could not run (default: exit 2)",
     )
 
     args = parser.parse_args()
@@ -239,6 +257,8 @@ def main():
     if args.output:
         report_data = {
             "project": str(project_path),
+            "scanners_failed": failed_scanners(results),
+            "scanner_failures": len(failed_scanners(results)),
             "results": [
                 {
                     "tool": r.tool,
@@ -257,6 +277,10 @@ def main():
     # issues, vulnerable dependencies, ERROR-level SAST hits, or any secret).
     if any(r.blocking for r in results):
         sys.exit(1)
+    # A requested scanner that never ran leaves that class of finding unchecked,
+    # so it cannot be reported as a clean audit.
+    if failed_scanners(results) and not args.allow_scanner_failure:
+        sys.exit(2)
     sys.exit(0)
 
 

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -1,0 +1,188 @@
+import contextlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = (
+    Path(__file__).parents[1]
+    / "skills"
+    / "python"
+    / "security-audit"
+    / "scripts"
+    / "security_scan.py"
+)
+SPEC = importlib.util.spec_from_file_location("security_scan", SCRIPT)
+assert SPEC and SPEC.loader
+SECURITY_SCAN = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SECURITY_SCAN
+SPEC.loader.exec_module(SECURITY_SCAN)
+
+
+def result(tool, success=True, findings=None, blocking=0, error=None):
+    return SECURITY_SCAN.ScanResult(tool, success, findings or [], blocking, error)
+
+
+class RunFailureTests(unittest.TestCase):
+    """A scanner that cannot launch must be recorded, not raised."""
+
+    def test_missing_scanner_reports_the_install_hint(self):
+        with mock.patch.object(SECURITY_SCAN.subprocess, "run", side_effect=FileNotFoundError):
+            stdout, err = SECURITY_SCAN._run(["bandit"], "bandit", "uv tool install bandit")
+
+        self.assertIsNone(stdout)
+        self.assertFalse(err.success)
+        self.assertEqual(err.tool, "bandit")
+        self.assertEqual(err.blocking, 0)
+        self.assertIn("uv tool install bandit", err.error)
+
+    def test_timed_out_scanner_is_recorded_as_a_failure(self):
+        timeout = subprocess.TimeoutExpired(cmd=["semgrep"], timeout=SECURITY_SCAN.SCAN_TIMEOUT)
+        with mock.patch.object(SECURITY_SCAN.subprocess, "run", side_effect=timeout):
+            stdout, err = SECURITY_SCAN._run(["semgrep"], "semgrep", "uv tool install semgrep")
+
+        self.assertIsNone(stdout)
+        self.assertFalse(err.success)
+        self.assertEqual(err.blocking, 0)
+        self.assertIn("timed out", err.error)
+
+
+class ReportTests(unittest.TestCase):
+    """The console summary must not read as a clean audit when nothing ran."""
+
+    def test_summary_names_the_scanners_that_did_not_run(self):
+        report = SECURITY_SCAN.format_report(
+            [
+                result("bandit", success=False, error="bandit not installed."),
+                result("pip-audit"),
+                result("semgrep", success=False, error="semgrep timed out after 300s"),
+            ]
+        )
+
+        self.assertIn("Total findings: 0 (0 blocking)", report)
+        self.assertIn("Scanners that did not run: 2 (bandit, semgrep)", report)
+
+    def test_summary_is_quiet_when_every_scanner_ran(self):
+        report = SECURITY_SCAN.format_report([result("bandit"), result("pip-audit")])
+
+        self.assertIn("Total findings: 0 (0 blocking)", report)
+        self.assertNotIn("did not run", report)
+
+
+class ExitCodeTests(unittest.TestCase):
+    """Exit status is the gate: 0 clean, 1 blocking, 2 a scanner never ran."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.project = Path(self.temp_dir.name).resolve()
+
+    def run_main(self, results, *extra_args):
+        argv = ["security_scan.py", str(self.project), *extra_args]
+        runners = {
+            "run_bandit": "bandit",
+            "run_pip_audit": "pip-audit",
+            "run_semgrep": "semgrep",
+            "check_secrets": "detect-secrets",
+        }
+        out = io.StringIO()
+        original_argv = sys.argv
+        sys.argv = argv
+        patches = [
+            mock.patch.object(SECURITY_SCAN, attr, lambda _p, tool=tool: results[tool])
+            for attr, tool in runners.items()
+        ]
+        try:
+            with contextlib.ExitStack() as stack:
+                for patch in patches:
+                    stack.enter_context(patch)
+                with contextlib.redirect_stdout(out), self.assertRaises(SystemExit) as raised:
+                    SECURITY_SCAN.main()
+        finally:
+            sys.argv = original_argv
+        return raised.exception.code, out.getvalue()
+
+    @staticmethod
+    def clean():
+        return {
+            "bandit": result("bandit"),
+            "pip-audit": result("pip-audit"),
+            "semgrep": result("semgrep"),
+            "detect-secrets": result("detect-secrets"),
+        }
+
+    def test_clean_scan_exits_zero(self):
+        code, output = self.run_main(self.clean())
+
+        self.assertEqual(code, 0)
+        self.assertNotIn("did not run", output)
+
+    def test_blocking_finding_exits_one(self):
+        results = self.clean()
+        results["bandit"] = result(
+            "bandit", findings=[{"issue_text": "eval", "issue_severity": "HIGH"}], blocking=1
+        )
+
+        code, _ = self.run_main(results)
+
+        self.assertEqual(code, 1)
+
+    def test_scanner_that_did_not_run_exits_two(self):
+        results = self.clean()
+        results["semgrep"] = result("semgrep", success=False, error="semgrep not installed.")
+
+        code, output = self.run_main(results)
+
+        self.assertEqual(code, 2)
+        self.assertIn("Scanners that did not run: 1 (semgrep)", output)
+
+    def test_blocking_finding_still_wins_over_a_failed_scanner(self):
+        results = self.clean()
+        results["semgrep"] = result("semgrep", success=False, error="semgrep not installed.")
+        results["detect-secrets"] = result(
+            "detect-secrets", findings=[{"file": "a.py", "type": "AWS", "line": 3}], blocking=1
+        )
+
+        code, _ = self.run_main(results)
+
+        self.assertEqual(code, 1)
+
+    def test_allow_scanner_failure_restores_the_tolerant_exit(self):
+        results = self.clean()
+        results["semgrep"] = result("semgrep", success=False, error="semgrep not installed.")
+
+        code, output = self.run_main(results, "--allow-scanner-failure")
+
+        self.assertEqual(code, 0)
+        self.assertIn("Scanners that did not run: 1 (semgrep)", output)
+
+    def test_skipped_scanner_is_not_a_failure(self):
+        results = self.clean()
+        results["semgrep"] = result("semgrep", success=False, error="semgrep not installed.")
+
+        code, output = self.run_main(results, "--skip", "semgrep")
+
+        self.assertEqual(code, 0)
+        self.assertNotIn("did not run", output)
+
+    def test_json_report_records_the_scanners_that_did_not_run(self):
+        results = self.clean()
+        results["bandit"] = result("bandit", success=False, error="bandit not installed.")
+        report_path = self.project / "report.json"
+
+        code, _ = self.run_main(results, "--output", str(report_path))
+
+        self.assertEqual(code, 2)
+        payload = json.loads(report_path.read_text())
+        self.assertEqual(payload["scanners_failed"], ["bandit"])
+        self.assertEqual(payload["scanner_failures"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #77

`security_scan.py` records a missing, unlaunchable, or timed-out scanner as `ScanResult(success=False, blocking=0)`, and `main()` gated only on `blocking` — so a run in which nothing was scanned printed `Total findings: 0 (0 blocking)` and exited `0`, indistinguishable from a clean audit. Both `SKILL.md` and `CI_SECURITY.md` document the script as a single CI gate.

## What changed

- **Exit contract.** `1` on blocking findings (unchanged, and it still wins when both conditions hold), `2` when a requested scanner did not run, `0` only when every requested scanner ran and nothing blocking was found. New `--allow-scanner-failure` restores the previous tolerant behaviour. A `--skip`ped scanner produces no result at all, so it is never counted as a failure.
- **Console summary.** New `failed_scanners()` helper; `format_report` appends `Scanners that did not run: 2 (bandit, semgrep)` beside the existing `Total findings:` line when any scanner failed (nothing is printed on a clean run).
- **`--output` JSON.** Adds top-level `scanners_failed` (list of tool names) and `scanner_failures` (count); per-result fields are unchanged.
- **`tests/test_security_scan.py`** — new module, loaded by path with the same `spec_from_file_location` + `exec_module` preamble the existing test modules use. Covers `_run` on `FileNotFoundError` and `TimeoutExpired` (patching `subprocess.run`), `format_report` naming the failed scanners, and the exit-code matrix driven through `main()` with a patched `sys.argv` and stubbed runners.
- **Docs.** `SKILL.md` quick start and script description, and `CI_SECURITY.md`'s bundled-script section, now state the exit codes, the opt-out flag, and that `--skip` is the way to exclude a scanner deliberately.

No new dependencies; stdlib `unittest` only.

## Verification

Suite (was 24 tests, now 34):

```
$ uv run python -m unittest discover -s tests
Ran 34 tests in 0.034s
OK
```

End-to-end on a throwaway project with none of the four scanners on `PATH` (`env PATH=/usr/bin:/bin`, CPython 3.12):

```
Total findings: 0 (0 blocking)
Scanners that did not run: 4 (bandit, pip-audit, semgrep, detect-secrets)
EXITCODE=2
```

…and the same run with `--allow-scanner-failure` exits `0` while still printing the `Scanners that did not run: 4 (...)` line. The written `report.json` carries `"scanners_failed": ["bandit", "pip-audit", "semgrep", "detect-secrets"]`.

**Mutation check** (fix committed first, restored with `git checkout` afterwards, `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared; suite re-run green after each restore):

- Reverted **only** the exit-code change (deleted the `sys.exit(2)` branch) → 2 failures: `test_scanner_that_did_not_run_exits_two` and `test_json_report_records_the_scanners_that_did_not_run` (`AssertionError: 0 != 2`). Every report test still passed.
- Reverted **only** the report change (deleted the `Scanners that did not run:` line) → 3 failures: `test_summary_names_the_scanners_that_did_not_run`, plus the two exit-code tests that also assert on the summary text. The pure exit-code assertions still passed.

Lint (no repo config or CI gate; baseline established with `git stash`): `security_scan.py` has the same 2 pre-existing default-ruleset findings on this branch as on `main` (`EXE001`, `PLW1510`); `tests/test_security_scan.py` trips only `I001`, matching the existing test modules' two-blank-lines-after-imports style.