### PR TITLE
[autopilot] skills: add wiring-application-config for layered config loading and validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.17.0",
+    "version": "2.18.0",
     "homepage": "https://github.com/wdm0006/python-skills",
-    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation", "derived-metrics", "thresholds", "statistics", "nullability", "event-loop", "concurrency"]
+    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation", "derived-metrics", "thresholds", "statistics", "nullability", "event-loop", "concurrency", "configuration", "config-validation", "settings", "defaults-merge"]
   },
   "plugins": [
     {
@@ -40,7 +40,8 @@
         "./skills/common/reproducing-ci-locally",
         "./skills/common/cross-surface-changes",
         "./skills/common/derived-metrics",
-        "./skills/common/verifying-external-behavior"
+        "./skills/common/verifying-external-behavior",
+        "./skills/common/app-config"
       ]
     },
     {
@@ -98,6 +99,15 @@
       ]
     },
     {
+      "name": "wiring-application-config",
+      "description": "Load, merge and validate layered application configuration so a mis-wired or misspelled key fails loudly instead of reverting to the default - sections the code reads that exist nowhere, sections nothing reads, unvalidated recursive merges, bool passing as int, defaults aliased by a shallow merge, falsy-but-valid values killed by or/||, partial write-backs stickier than a missing file, and bootstrap ordering that swallows the loader's own warnings",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/common/app-config"
+      ]
+    },
+    {
       "name": "python-llm-features",
       "description": "Build application features on top of an LLM API - prompt surfaces that drift, filtered evaluator sets that cannot silently become clean passes, model config wiring, live-model tests kept out of CI, stochastic accuracy evaluation, and truthful presentation of model output",
       "source": "./",
@@ -114,7 +124,8 @@
       "strict": false,
       "skills": [
         "./skills/python/mcp-servers",
-        "./skills/common/cross-surface-changes"
+        "./skills/common/cross-surface-changes",
+        "./skills/common/app-config"
       ]
     },
     {
@@ -124,7 +135,8 @@
       "strict": false,
       "skills": [
         "./skills/python/web-app-architecture",
-        "./skills/common/rendering-untrusted-content"
+        "./skills/common/rendering-untrusted-content",
+        "./skills/common/app-config"
       ]
     },
     {
@@ -215,6 +227,7 @@
       "strict": false,
       "skills": [
         "./skills/javascript/browser-extensions",
+        "./skills/common/app-config",
         "./skills/common/build-artifacts",
         "./skills/common/rendering-untrusted-content",
         "./skills/common/git-hygiene",

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Or install a language-agnostic bundle:
 
 # Compute and report statistics, scores, and flags honestly
 /plugin install reporting-derived-metrics@dev-skills
+
+# Load, merge, and validate layered application configuration
+/plugin install wiring-application-config@dev-skills
 ```
 
 ### Alternative: Local Installation
@@ -183,6 +186,7 @@ After installation, you can verify the skills are loaded by running:
 | **reproducing-ci-locally** | Make the local check agree with the runner — deriving the command, paths, marker expression and `env:` from the workflow file rather than the Makefile, running each gate step separately because the first failure hides the rest, pinning the linter version CI resolves (an unpinned formatter that widens file coverage reddens every open PR), building the interpreter and extras the runner builds, fixing divergence in shared config rather than in the YAML, and confirming a run is green instead of explaining a red job away | — |
 | **reporting-derived-metrics** | Compute statistics, scores, and flags from samples that may be too small to support them — undefined dispersion returned as `0.0` and tripping the minimum threshold it is compared against (the least data producing the strongest verdict), `None` vs `0`/`-1`/`NaN` as the sentinel, threshold blocks gated on whether the value was measured, report sentences that narrate findings from absent data, nullability as a public API change, `is None` vs truthiness when `[]`/`0` are real results, and broad excepts that disguise a metric bug as a normal-shaped result | — |
 | **shipping-across-surfaces** | Land a change everywhere the same fact is stated — enumerating the surface inventory (landing copy, structured data, docs, `llms.txt`, changelog plus the version badge repeated in every page's nav, sitemap, README, descriptions embedded in code, and untyped frontend consumers of typed responses), generating a surface instead of restating it, drift tests that compare against the live registry rather than a second hand-written list, never hand-maintaining a snapshot of a surface another codebase owns, paired producer/consumer PRs for format changes, and keeping overloaded product words apart | — |
+| **wiring-application-config** | Load, merge, and validate layered configuration (defaults plus a user YAML/TOML/JSON file or a stored settings object) so a mis-wired key fails loudly — sections the code reads that exist nowhere and sections nothing reads, strictness at the load boundary instead of `.get(key, default)` in every consumer, unknown keys and wrong types dropped with a warning naming the dotted path, `bool` excluded before any integer check, defaults deep-copied so a merge cannot alias them, `get(key, default)`/`??` rather than `or`/`||` for falsy-but-valid values, write-backs that re-read and merge over full defaults, and bootstrap logging ordered so the loader's own warnings survive | — |
 
 ## Plugin Bundles
 
@@ -194,15 +198,15 @@ After installation, you can verify the skills are loaded by running:
 - **shipping-swift-apps** — TestFlight/App Store releases on their own (App Store Connect API key auth, fastlane metadata lanes, headless archive and upload, build-number and version-train rules) for when the build side is already sorted.
 - **rust-crates** — `building-rust-crates` + `keeping-git-repos-clean`.
 - **scala-projects** — `building-scala-projects` + `keeping-git-repos-clean`.
-- **browser-extensions** — `building-browser-extensions` + `shipping-build-artifacts` + `rendering-untrusted-content` + `keeping-git-repos-clean`.
+- **browser-extensions** — `building-browser-extensions` + `wiring-application-config` + `shipping-build-artifacts` + `rendering-untrusted-content` + `keeping-git-repos-clean`.
 
 ### Narrower Python bundles
 
 - **python-library-foundations** — project setup, code quality, testing strategy.
 - **python-library-distribution** — packaging, release management, CLI development, build-artifact shipping.
 - **python-library-quality** — security audit, performance, API design, untrusted-content rendering, external-behavior verification, git hygiene.
-- **python-web-app** — web-app architecture (FastAPI, async SQLAlchemy, Stripe, Docker/Terraform deployment) + untrusted-content rendering.
-- **python-mcp-servers** — MCP servers (FastMCP tool design, error contracts, event-loop-safe blocking work, packaging, testing, prompt-injection awareness).
+- **python-web-app** — web-app architecture (FastAPI, async SQLAlchemy, Stripe, Docker/Terraform deployment) + untrusted-content rendering + application-config wiring.
+- **python-mcp-servers** — MCP servers (FastMCP tool design, error contracts, event-loop-safe blocking work, packaging, testing, prompt-injection awareness) + application-config wiring.
 - **python-llm-features** — LLM-backed features (prompt surfaces, structured outputs, context budgeting, model config wiring, accuracy evaluation).
 
 ### Language-agnostic
@@ -213,6 +217,7 @@ After installation, you can verify the skills are loaded by running:
 - **reproducing-ci-locally** — running the CI gate on your machine so it agrees with the runner (workflow-derived commands and markers, short-circuiting gate steps, pinned linter versions, the runner's interpreter and extras, confirming green).
 - **reporting-derived-metrics** — scoring and analysis pipelines, z-score/outlier checks, quality and anomaly flags, and metrics rollups (unmeasurable is not zero, gate the threshold on whether the value was measured, never narrate a finding from absent data).
 - **shipping-across-surfaces** — landing a user-facing change everywhere the same fact is stated (surface inventory, typed-response/untyped-consumer contract tests, generated instead of restated surfaces, drift tests against the live registry, cross-repo format contracts and direction of ownership, overloaded product terms).
+- **wiring-application-config** — config loaders, merge helpers, schemas, and stored settings objects (check both ends of every key, validate at the load boundary, drop unknown keys with a warning naming the dotted path, never alias the defaults you merged from, never persist a partial settings object).
 
 Every language bundle includes **keeping-git-repos-clean** — committed-secret and dev-artifact hygiene applies regardless of language.
 

--- a/skills/common/app-config/SKILL.md
+++ b/skills/common/app-config/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: wiring-application-config
+description: Load, merge, and validate layered application configuration (defaults plus a user YAML/TOML/JSON file or a stored settings object) so a mis-wired or misspelled key fails loudly instead of silently reverting to the default — sections the code reads that exist nowhere, sections that exist but nothing reads, unvalidated recursive merges, `bool`-passes-as-`int`, defaults aliased by a shallow merge, falsy-but-valid values killed by `or`/`||`, partial write-backs that are stickier than a missing file, and bootstrap ordering that swallows the loader's own warnings. Use when adding a config key, writing or reviewing a config loader/merge/schema, reading a setting in a new module, persisting user settings, wiring logging from config, or debugging a setting that "has no effect".
+---
+
+# Wiring Application Configuration
+
+Configuration bugs are quiet because every layer on the path has a fallback. A
+value travels defaults → user file → merge → consumer, and each hop can drop it
+without raising anything. The result is an application that starts cleanly,
+reports success, and runs on values the user did not choose.
+
+**Use a typed settings model when you can.** `pydantic-settings`, a tagged
+struct, or any schema-first loader collapses most of this page into one class:
+unknown keys and wrong types fail at construction, and every consumer gets
+attribute access instead of `config["a"]["b"]`. Reach for the hand-rolled merge
+below only when you genuinely need a layered file surface the typed model
+doesn't cover — and then port the guarantees, don't skip them.
+
+## A config key is a contract between two files. Check both ends.
+
+The reader indexes one section; the defaults declare another:
+
+```python
+# consumer
+cache_cfg = config["cache"]         # section name that exists nowhere
+store = ResultStore(cache_cfg)
+
+# defaults.py
+DEFAULT_CONFIG = {"storage": {"backend": "...", "max_entries": 512, ...}}
+```
+
+Nothing fails at load. Nothing fails at startup. Every request through that path
+returns `{"error": "Request failed: 'max_entries'"}` — a `KeyError` caught by a
+broad `except` several frames away and folded into a normal-shaped result. That
+can ship for months, because tests that assert on the result's *shape* pass.
+
+So make this the first check on any config lookup you write or review: **does
+the section this code reads actually exist in the defaults?** It is a grep, not
+an inspection:
+
+```bash
+# every section name the code reads
+grep -rhoE 'config(\.get\(|\[)"[a-z_]+"' src/ | grep -oE '"[a-z_]+"' | sort -u
+# each one must appear in the defaults module
+```
+
+Run it in the other direction too. A section that appears **only** in the
+defaults and the schema is inert: the user sets it, validation accepts it, and
+nothing reads it. Separate the two causes before "fixing" it —
+
+- **Unwired**: something is supposed to consume it and doesn't. That is a bug;
+  wire it up.
+- **Unimplemented**: the key describes a capability nobody built (a
+  config-driven directory when the directory is a module constant). That is a
+  feature request. Don't implement it under cover of a wiring fix — and don't
+  leave a documented key that silently does nothing either. Say which it is.
+
+## Be strict at the boundary, permissive after it
+
+The same config dict is routinely consumed at two strictness levels: the loader
+or manager uses `cfg.get("backend", DEFAULT)`, and a deeper function
+hard-indexes `cfg["max_entries"]`. A partial config then loads fine, constructs
+objects fine, and explodes deep inside a request — where the broad `except`
+turns it into an error-shaped response.
+
+Pick one place to be strict — the load boundary — and validate there. After
+that, missing keys shouldn't be possible, so `[...]` indexing downstream is
+correct and self-documenting. `.get(key, default)` scattered through consumers
+is what makes a typo survive to production: it silently supplies a plausible
+value for a key that was never spelled correctly anywhere.
+
+## Validate the file surface at load; drop unknown keys with a warning
+
+A recursive merge that accepts whatever the YAML contained has two failure
+modes, both silent:
+
+- `storage.max_entires: 1024` is retained under the misspelled name while the
+  real `max_entries` keeps its default. The user sees their key in the file and
+  concludes it works.
+- `storage: redis` — a scalar where a mapping belongs — survives the load and
+  fails only when something treats it as a mapping.
+
+Declare the surface, validate before merging, and warn with the **full dotted
+path** so the message is actionable:
+
+```python
+CONFIG_SCHEMA = {
+    "storage": {"backend": STRING, "max_entries": INTEGER, "batch_size": INTEGER},
+    "logging": {"level": STRING, "format": STRING},
+}
+
+def _validate(node, schema, path=""):
+    clean = {}
+    for key, value in node.items():
+        dotted = f"{path}.{key}" if path else key
+        expected = schema.get(key)
+        if expected is None:
+            logger.warning("Unknown config key %r — ignored", dotted)
+        elif isinstance(expected, dict):
+            if isinstance(value, dict):
+                clean[key] = _validate(value, expected, dotted)
+            else:
+                logger.warning("Config key %r must be a mapping — ignored", dotted)
+        elif _matches_kind(value, expected):
+            clean[key] = value
+        else:
+            logger.warning("Config key %r has wrong type — ignored", dotted)
+    return clean
+```
+
+**Exclude `bool` explicitly in any numeric type check.** `isinstance(True, int)`
+is `True` in Python, and the same widening bites in most dynamic languages, so
+`batch_size: true` sails through a naive integer check and becomes `1` deep in an
+arithmetic path. `_matches_kind` must short-circuit on `isinstance(value, bool)`
+*before* the integer branch.
+
+## Validation makes config a closed surface — add a coverage test
+
+Once unknown keys are dropped, the schema is load-bearing in a new direction:
+**anything you add to the defaults, or to the config file you ship, must also be
+added to the schema or it is silently discarded at load.** The warning goes to a
+log nobody is reading during development.
+
+Two cheap guards, both worth having:
+
+```python
+def test_defaults_are_declared():
+    assert leaf_paths(DEFAULT_CONFIG) <= leaf_paths(CONFIG_SCHEMA)
+
+def test_shipped_config_validates_without_warnings(caplog):
+    load_config("config.example.yaml")
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+```
+
+Declare the **documented** surface, not just the consumed subset. Keys that ship
+in your own example config belong in the schema even if nothing reads them yet —
+otherwise every load of your own file emits warnings. Tightening the schema down
+to the consumed subset is fine, but it has to edit the shipped file in the same
+change.
+
+## A merge that recurses on dicts only aliases your defaults
+
+Deep-merge helpers usually recurse into dicts and copy everything else by
+reference. Every list, set, or nested object in the defaults is then **shared**
+with the loaded config, and a later mutation of the loaded config reaches back
+into a module-level global that the rest of the process — and every other test
+in the run — reads from.
+
+The same bug wears a different hat in JS: `{...DEFAULTS, lastIndex: i}` copies
+the top level and aliases every nested object. Merge nested keys explicitly, or
+deep-copy the defaults before merging:
+
+```python
+merged = copy.deepcopy(DEFAULT_CONFIG)   # not {**DEFAULT_CONFIG}
+```
+
+It costs nothing at startup and removes a whole class of cross-test bleed.
+
+## Falsy is not missing
+
+```python
+timeout = cfg.get("timeout") or 30        # a configured 0 becomes 30
+start_hour = settings.get("start") or 9   # midnight becomes 9am
+```
+
+`0`, `""`, `False`, and `[]` are all legitimate configured values. Use
+`cfg.get(key, default)` in Python and `??` in JavaScript, never `or`/`||`, for
+any setting whose valid range includes a falsy value — hours, counts,
+thresholds, retry limits, feature flags.
+
+## Never persist a partial settings object
+
+Writing back a spread of whatever you just read is fine until the read returns
+nothing:
+
+```javascript
+// Bad — if `settings` was absent, this persists an object missing every other key
+await storage.set({ settings: { ...settings, lastIndex: i } });
+```
+
+A *missing* config self-heals: `settings ?? DEFAULTS` catches it. A *partial*
+one does not — it is truthy, so the reader keeps it and throws on the first
+nested key, and the corruption is sticky across restarts. Read-modify-write
+rules:
+
+1. **Re-read** immediately before writing, so a concurrent writer's change isn't
+   lost.
+2. **Merge over the full defaults**, spelling out nested keys, so the persisted
+   object is always complete.
+3. **Await the write** — a worker or page that is torn down mid-write loses it.
+
+Validate user-entered values before they reach storage, too. A field parsed with
+a bare `int()`/`parseInt()` yields `None`/`NaN`, serializes to `null`, and is
+silently replaced by the default on the next read — while the UI says "saved".
+Declarative constraints that nothing evaluates (an HTML `min`/`max` on a form
+that is never submitted) are inert; enforce the range in code.
+
+## Bootstrap ordering: don't swallow the loader's own warnings
+
+When config configures logging, the order is fixed:
+
+1. `basicConfig` with hardcoded defaults, **before** `load_config()` — the
+   loader emits the "unknown key / wrong type" warnings, and they must land
+   somewhere.
+2. Re-apply level and format from the loaded config afterwards.
+
+Two details that bite:
+
+- **Keep the output stream pinned in both calls.** A process that speaks a
+  protocol over stdout (stdio JSON-RPC, a CLI whose stdout is piped into another
+  tool) corrupts that stream the moment a log record goes to it. Log to stderr,
+  explicitly, in the bootstrap call and the reconfigure call.
+- **Resolve the level before applying it.** `basicConfig(level="LOUD",
+  force=True)` removes the existing handlers *before* raising on the bad level,
+  so an invalid value can leave the process with no logging at all. Look the
+  level up first, fall back to the default with a warning, and never let a bad
+  config value raise out of the logging setup.
+
+## Testing
+
+- **Give the loader a `config_path` parameter** and write a real file into a
+  temp directory. That is far cheaper and truer than stacking patches on `open`,
+  `Path.exists`, and `yaml.safe_load`, and it lets you assert on the returned
+  values *and* the warning text in one test.
+- **Always pass an explicit path.** A default path resolved relative to the
+  current working directory means a bare `load_config()` in a test reads the
+  repo's own shipped file — so editing that file changes the outcome of
+  unrelated tests. The single exception is the test that deliberately validates
+  the shipped file.
+- **Assert `"error" not in result`** in tests that exercise a config-consuming
+  code path. Where a broad `except` wraps the consumer, that assertion is the
+  only thing separating a mis-wired key from a working one.
+- **Mutation-test the wiring.** Rename the section back to the wrong name; some
+  test must go red. If the suite stays green, your coverage is shape assertions,
+  not behavior. Separately, drop the `bool` short-circuit from the type check —
+  exactly one test should fail.
+- **Test the typo, not just the happy path.** A config with a misspelled key
+  must produce a warning naming the dotted path *and* leave the real key at its
+  default.
+
+## Checklist
+
+- [ ] Every section the code reads exists in the defaults (grep both directions)
+- [ ] Every section in the defaults/shipped file is read by something, or is
+      explicitly labelled unimplemented rather than left silently inert
+- [ ] Strict validation at the load boundary; consumers index instead of
+      `.get(key, default)`-ing a required key
+- [ ] Unknown keys and wrong types dropped with a warning naming the dotted path
+- [ ] `bool` excluded before any integer/number type check
+- [ ] Defaults ⊆ schema asserted by a test; shipped config validates warning-free
+- [ ] Schema covers the documented surface, not just the consumed subset
+- [ ] Defaults deep-copied before merge — no list/nested object shared by reference
+- [ ] `get(key, default)` / `??` rather than `or` / `||` for any falsy-valid value
+- [ ] Write-backs re-read, merge over full defaults, and are awaited
+- [ ] User input range-checked in code, not by inert declarative constraints
+- [ ] Bootstrap logging configured before `load_config()`; stream pinned in both;
+      an unknown level falls back with a warning instead of raising
+- [ ] Loader takes an explicit path; tests never rely on the cwd-relative default
+
+Related: **reporting-derived-metrics** for how a broad `except` disguises a
+mis-wired key as a normal-shaped result, **verifying-external-behavior** for
+confirming what a permissive client does with an argument it doesn't recognise,
+and **shipping-across-surfaces** for keeping a documented config key in step with
+the code that reads it.


### PR DESCRIPTION
## What changed

New language-agnostic skill: `skills/common/app-config/SKILL.md` (`wiring-application-config`), plus registration in `.claude-plugin/marketplace.json` and the README.

It covers:

- **Check both ends of every key.** A consumer that reads `config["cache"]` while the defaults declare `storage` fails at neither load nor startup — it surfaces frames away as an error-shaped result. Includes a grep that runs the check in both directions, and separates *unwired* (a bug) from *unimplemented* (a feature request) for keys nothing reads.
- **Be strict at the load boundary, permissive after it.** The same dict consumed at two strictness levels — `.get(key, default)` in one place, hard-indexing in another — lets a partial config construct objects fine and explode deep inside a request.
- **Validate the file surface; drop unknown keys with a warning naming the dotted path.** A misspelled key retained under its wrong name while the real one keeps its default is the quietest config bug there is. Includes the `bool`-before-`int` short-circuit (`isinstance(True, int)` is `True`).
- **Validation makes config a closed surface** — a defaults-⊆-schema test and a shipped-file-validates-warning-free test, and why the schema should declare the documented surface rather than the consumed subset.
- **Merges that recurse on dicts only alias the defaults** they merged from (same bug as a shallow JS spread of a defaults object with nested keys).
- **Falsy is not missing** — `or`/`||` on a setting whose valid range includes `0`.
- **Never persist a partial settings object** — a missing config self-heals via `x ?? DEFAULTS`; a partial one is truthy, sticky, and throws on the first nested key.
- **Bootstrap ordering** — configure logging with hardcoded defaults *before* the loader runs, or its own "key dropped" warnings are swallowed; pin the stream so a stdio protocol isn't corrupted; resolve an unknown level rather than letting it raise after handlers are already torn down.
- **Testing** — give the loader an explicit path parameter instead of stacking patches, never rely on a cwd-relative default, assert `"error" not in result`, and mutation-test the wiring.

## Which pattern motivated it

Across several codebases the same failure kept recurring: a configuration value that the user set, the loader accepted, and nothing ever applied. The concrete shapes were a consumer indexing a config section that existed in no defaults file (every request through that path returned an error-shaped result for months, because the tests asserted on result *shape*); a recursive merge that retained a misspelled key verbatim while the real one stayed at its default; a whole documented config section that no source file read; a numeric setting whose valid `0` was replaced by a default via `||`; and a settings write-back that persisted a partial object which then poisoned every subsequent read. Each was found and fixed independently, in different languages, with no shared guidance to prevent the next one — which is exactly the case for a skill.

## How a reader benefits

Config wiring is normally reviewed by reading the diff, which is the one view that cannot show this class of bug: both halves of a mis-wired key look correct in isolation. The skill turns that into mechanical checks a reader can actually run — two greps, two coverage tests, one type-check short-circuit, and a checklist — and states the ordering and write-back rules that keep a validated config from silently discarding the values it just validated.