### PR TITLE
[autopilot] skills: add guarding-destructive-operations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,9 +6,9 @@
   },
   "metadata": {
     "description": "Opinionated, checklist-driven skills for professional software development across languages - Python libraries and web apps, Go projects, Swift/Apple apps, Rust crates, Scala projects, and browser extensions",
-    "version": "2.20.0",
+    "version": "2.21.0",
     "homepage": "https://github.com/wdm0006/python-skills",
-    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation", "derived-metrics", "thresholds", "statistics", "nullability", "event-loop", "concurrency", "configuration", "config-validation", "settings", "defaults-merge", "merge-conflicts", "concurrent-branches", "rebasing", "hotspot-files", "generated-artifacts", "lazy-loading", "cold-start", "import-time", "model-loading"]
+    "keywords": ["python", "go", "swift", "rust", "scala", "javascript", "browser-extension", "library", "packaging", "testing", "ci", "api-design", "xss", "sanitization", "sync-jobs", "integration-testing", "api-contracts", "build-scripts", "release-artifacts", "ci-reproduction", "linting", "dev-environment", "docs-sync", "cross-repo", "product-copy", "password-security", "bcrypt", "distributed-rate-limiting", "redis", "testflight", "app-store-connect", "fastlane", "xcodebuild", "code-signing", "release-automation", "derived-metrics", "thresholds", "statistics", "nullability", "event-loop", "concurrency", "configuration", "config-validation", "settings", "defaults-merge", "merge-conflicts", "concurrent-branches", "rebasing", "hotspot-files", "generated-artifacts", "lazy-loading", "cold-start", "import-time", "model-loading", "destructive-operations", "path-traversal", "blast-radius"]
   },
   "plugins": [
     {
@@ -43,7 +43,8 @@
         "./skills/common/derived-metrics",
         "./skills/common/verifying-external-behavior",
         "./skills/common/app-config",
-        "./skills/common/concurrent-branches"
+        "./skills/common/concurrent-branches",
+        "./skills/common/destructive-operations"
       ]
     },
     {
@@ -122,6 +123,15 @@
       ]
     },
     {
+      "name": "guarding-destructive-operations",
+      "description": "Put real preconditions on operations that delete, overwrite, or rewrite history, and on code that turns a caller-supplied name into a path - refusing instead of warning, guards placed ahead of the first mutation, structural ownership checks rather than string prefixes, name validation plus resolved-path containment as two independent checks, the deliberate dry-run gap, and mutation-testing each half separately",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/common/destructive-operations"
+      ]
+    },
+    {
       "name": "python-llm-features",
       "description": "Build application features on top of an LLM API - prompt surfaces that drift, filtered evaluator sets that cannot silently become clean passes, model config wiring, live-model tests kept out of CI, stochastic accuracy evaluation, and truthful presentation of model output",
       "source": "./",
@@ -188,6 +198,7 @@
         "./skills/python/api-design",
         "./skills/common/rendering-untrusted-content",
         "./skills/common/verifying-external-behavior",
+        "./skills/common/destructive-operations",
         "./skills/common/git-hygiene",
         "./skills/common/github-actions"
       ]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Or install a language-agnostic bundle:
 
 # Keep expensive resources off cheap code paths
 /plugin install deferring-heavy-dependencies@dev-skills
+
+# Guard deletes, history rewrites, and caller-supplied file paths
+/plugin install guarding-destructive-operations@dev-skills
 ```
 
 ### Alternative: Local Installation
@@ -195,6 +198,7 @@ After installation, you can verify the skills are loaded by running:
 | **shipping-across-surfaces** | Land a change everywhere the same fact is stated — enumerating the surface inventory (landing copy, structured data, docs, `llms.txt`, changelog plus the version badge repeated in every page's nav, sitemap, README, descriptions embedded in code, and untyped frontend consumers of typed responses), generating a surface instead of restating it, drift tests that compare against the live registry rather than a second hand-written list, never hand-maintaining a snapshot of a surface another codebase owns, paired producer/consumer PRs for format changes, and keeping overloaded product words apart | — |
 | **wiring-application-config** | Load, merge, and validate layered configuration (defaults plus a user YAML/TOML/JSON file or a stored settings object) so a mis-wired key fails loudly — sections the code reads that exist nowhere and sections nothing reads, strictness at the load boundary instead of `.get(key, default)` in every consumer, unknown keys and wrong types dropped with a warning naming the dotted path, `bool` excluded before any integer check, defaults deep-copied so a merge cannot alias them, `get(key, default)`/`??` rather than `or`/`||` for falsy-but-valid values, write-backs that re-read and merge over full defaults, and bootstrap logging ordered so the loader's own warnings survive | — |
 | **concurrent-branches** | Resolve conflicts when several branches are open against one repo at once — finding the hotspot files nearly every commit touches, additive registries unioned rather than chosen (a taken side deletes a component that is still on disk), version and sequence fields recomputed from the integration branch instead of merged, generated artifacts (minified bundles, built PDFs, compiled schemas) rebuilt from resolved sources rather than text- or binary-merged, files serialized from maps sorted by a stable key so diffs stay reviewable, shared identifiers appended and never renumbered, duplicate test names after a union merge, and re-running the real gate because neither branch's CI covered their union | — |
+| **guarding-destructive-operations** | Put real preconditions on operations with no undo — irreversible bulk deletes and history rewrites that are only correct in a dedicated single-purpose target, refusing rather than warning and shipping no `--force`, placing the guard ahead of the first statement with an effect so a rejected run leaves everything byte-identical, structural ownership checks (`p == base or p.startswith(base + "/")`) instead of a bare prefix that admits `base-backup/`, name validation *and* resolved-path containment as two independent checks (only the second stops a symlink inside the directory), the deliberate dry-run gap, broad excepts upstream that turn a refusal into an ordinary result shape, and mutating each half of the guard separately | — |
 
 ## Plugin Bundles
 
@@ -228,6 +232,7 @@ After installation, you can verify the skills are loaded by running:
 - **wiring-application-config** — config loaders, merge helpers, schemas, and stored settings objects (check both ends of every key, validate at the load boundary, drop unknown keys with a warning naming the dotted path, never alias the defaults you merged from, never persist a partial settings object).
 - **merging-concurrent-branches** — rebasing or merging a branch into a repo taking parallel contributions (hotspot inventory, union vs. recompute vs. rebuild as three different correct resolutions, deterministic serialization, append-only identifiers, and the real gate re-run on the merged tree).
 - **deferring-heavy-dependencies** — a cheap operation that costs hundreds of milliseconds, or adding an expensive resource to a shared constructor or factory (lazy fields, factories split by need, cold-process per-call timing, one-time import vs repeated load, and asserting the loader is never called on a model-free path).
+- **guarding-destructive-operations** — `--rebuild`/`--reset`/`--purge` commands, bulk deletes, history rewrites, and any code that turns an argument into a file path (refuse instead of warn, guard before the first mutation, structural not string-prefix classification, validate the name *and* contain the resolved path, mutate each half separately in tests).
 
 Every language bundle includes **keeping-git-repos-clean** — committed-secret and dev-artifact hygiene applies regardless of language.
 

--- a/skills/common/destructive-operations/SKILL.md
+++ b/skills/common/destructive-operations/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: guarding-destructive-operations
+description: Add and review preconditions on operations that delete, overwrite, rewrite history, or resolve a caller-supplied name to a filesystem path — refusing instead of warning, placing the guard ahead of the first mutation, structural classification rather than string-prefix matching, name validation plus resolved-path containment as two independent checks, why a guard on the destructive path is invisible to the dry-run, and mutation-testing each half separately. Use when writing or reviewing a `--rebuild`/`--reset`/`--purge` command, a bulk delete, a history rewrite, an `rm -rf`-shaped step, or any code that turns an argument into a file path.
+---
+
+# Guarding Destructive Operations
+
+Some operations have no undo: an orphan-branch rewrite, a recursive delete of
+every tracked file, an overwrite of a stored artifact, a `DROP`/`purge` path. The
+implementation is usually short and usually correct *for the setup its author had
+in mind*. The bug is never the deletion itself — it is that nothing checked
+whether the target was the thing the author imagined.
+
+Two shapes recur, and they take the same fix:
+
+- **Blast radius.** The operation is correct only in a dedicated, single-purpose
+  target and is catastrophic in a mixed one.
+- **Boundary escape.** A caller-supplied name is joined onto a base directory and
+  lands outside it.
+
+## Refuse; don't warn, and don't add an override
+
+A destructive operation that discovers its precondition is violated should return
+an error and change nothing. A warning is read by nobody, and a `--force` escape
+hatch turns the guard into documentation.
+
+```go
+// A rebuild that recreates history does `checkout --orphan` then
+// `rm -rf --ignore-unmatch .`, keeping only the state files it rewrites.
+// That is correct in a dedicated mirror repository whose ONLY tracked content
+// is `.state/`. Run it where source code also lives and the new branch loses
+// the source code.
+func (e *Engine) rebuild() error {
+    if err := e.ensureDedicatedRepo(); err != nil {
+        return err   // nothing mutated yet
+    }
+    ...
+}
+```
+
+The honest justification for having no override flag: there is no situation where
+the operator wants this command to delete unrelated tracked files. If a real one
+appears later, that is a separate, differently-named command — not a boolean on
+this one.
+
+## Put the guard ahead of the first mutation
+
+"Refuses" is only true if the refusal happens before anything has changed.
+Walk the function and find the *first* statement with an effect — it is often not
+the obvious deletion. In-memory state clearing, a branch checkout, and a
+read-then-rewrite of the very files you are preserving all count.
+
+```go
+// Order that makes the refusal safe:
+//   1. reject detached HEAD / ambiguous state
+//   2. ensureDedicatedRepo()          <-- the new guard, nothing mutated yet
+//   3. read the state files to preserve
+//   4. CheckoutOrphan()
+//   5. RemoveAllTrackedFiles()
+//   6. ClearAllProgressCounts()
+```
+
+Steps 3–6 are all mutations of something (3 is not, but it is where the "what to
+preserve" snapshot is taken, and a guard after it has already committed you to a
+shape). Land the guard at 2 and a rejected run leaves the working tree byte-identical.
+
+Also refuse *ambiguous* state before rewriting it. A history rewrite that assumes
+a named branch should reject detached HEAD up front rather than silently
+recreating the wrong ref.
+
+## Classify structurally, not by string prefix
+
+The guard needs to answer "is every tracked path inside the directory this
+command owns?". A `HasPrefix`/`startswith` on the bare directory name is the
+wrong answer and looks right in every test you would think to write.
+
+```go
+// Bad — admits `.state-backup/notes.md` and `.stateful.txt`, so a repository
+// full of unrelated content passes the guard and gets deleted.
+func owned(path string) bool {
+    return strings.HasPrefix(path, ".state")
+}
+
+// Good — the directory itself, or something genuinely under it.
+func owned(path string) bool {
+    return path == ".state" || strings.HasPrefix(path, ".state/")
+}
+```
+
+The same distinction in Python is `Path(p) == base or base in Path(p).parents`,
+not `p.startswith(str(base))`. Any time a check compares paths as strings, ask
+what a sibling with a longer name does to it.
+
+## Name validation and resolved containment are two checks, not one
+
+When a public argument selects a file — a baseline name, a template id, a report
+slug — do both, in this order:
+
+```python
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+def _validate_name(name: str) -> str:
+    if ".." in name or not NAME_RE.match(name):
+        raise ValueError(f"invalid name: {name!r}")
+    return name
+
+def _resolve(name: str, base: Path) -> Path:
+    candidate = (base / f"{_validate_name(name)}.json").resolve()
+    if not candidate.is_relative_to(base.resolve()):
+        raise ValueError(f"name escapes {base}: {name!r}")
+    return candidate
+```
+
+The containment half is **not** redundant with the regex. The regex stops `..`
+segments and absolute paths; only the `resolve()` + containment check stops a
+*symlink placed inside the directory* that points out of it — a name matching
+`^[A-Za-z0-9]` all the way through can still resolve anywhere. Route every entry
+point through both: the loader, the saver, and any path-building helper a public
+method still calls directly. A single unrouted helper reinstates the whole hole.
+
+Without this, an implicit suffix (`name + ".json"`) plus an absolute-path
+argument reads any file on disk whose name happens to end in that suffix.
+
+## A guard on the destructive path is invisible to the preview
+
+If the real run reaches the guard but `--dry-run` short-circuits earlier, the
+preview cheerfully describes an operation the real run will refuse. That is a
+defensible design — the destructive path is the one that must be safe — but be
+explicit about it:
+
+- The preview will show a full rebuild in a repository where the rebuild is
+  forbidden. Only the real invocation errors.
+- Anything meant to warn the operator *earlier* has to live in the preview stage
+  or the CLI argument-validation layer, duplicated deliberately, not moved.
+
+Say which one you chose in the PR description; a reviewer cannot tell from the
+diff whether the dry-run gap is intentional.
+
+## Know what the caller does with your refusal
+
+Tightening validation only helps if the new error reaches somebody. A broad
+`except Exception` two frames up will turn a hard refusal into an ordinary
+result shape:
+
+```python
+try:
+    features = self._load(baseline)
+except Exception as e:                       # already there, catches your ValueError
+    return {"error": f"Analysis failed: {e}", "features": {}, "flags": {...}}
+```
+
+This is often *fine* — an API boundary that never raises is a real contract, and
+the refusal surfaces as a normal error-shaped response rather than a protocol
+error. But check it deliberately: if that shape is what your caller sees, the
+integration test asserts on `result["error"]`, not on `pytest.raises`.
+
+## Testing
+
+- **Mutate each half separately.** Neuter only the regex and confirm a `..`
+  fixture fails; neuter only the containment check and confirm a *symlink*
+  fixture fails. One combined test passes with either half deleted and proves
+  neither.
+- **Write the sibling-name fixture explicitly.** A test whose repository tracks
+  `.state/data.json` passes against `HasPrefix(path, ".state")` too. The test
+  that separates the implementations tracks `.state-backup/old.json` and asserts
+  the operation is refused.
+- **Assert nothing was mutated on refusal**, not just that an error came back:
+  the branch is unchanged, the tracked file list is unchanged, the in-memory
+  progress counters are unchanged. That is the actual claim.
+- **Existing fixtures become the rejected shape.** Older tests for the
+  destructive path were often built loosely — a repository tracking `app.txt`
+  alongside the state directory, because nothing cared. After the guard, such a
+  test no longer reaches the code it was written to cover; it now exercises the
+  refusal. Tighten those fixtures to the allowed shape and add the refusal case
+  as a *new* test, or you silently lose coverage of the destructive path.
+- **Reproduce the failure with the narrowest hook.** When you need one specific
+  operation to fail in order to test the recovery path, target it precisely — a
+  blanket hook that rejects every operation of that kind aborts the run earlier
+  than the path you were trying to reach, and the test proves something else.
+
+## Checklist
+
+- [ ] Every irreversible operation states its precondition in code, not in a doc
+- [ ] Violation returns an error; no `--force`, no warn-and-continue
+- [ ] The guard runs before the first statement with an effect
+- [ ] Ambiguous state (detached HEAD, missing target, multiple candidates) rejected up front
+- [ ] Path/ownership classification is structural, never a bare string prefix
+- [ ] Caller-supplied names are validated *and* resolved-path contained
+- [ ] Every entry point routes through both checks, including internal helpers
+- [ ] The dry-run/preview gap is intentional and stated
+- [ ] Tests mutate each half of the guard independently
+- [ ] A sibling-name (`x-backup/`) and a symlink fixture both exist
+- [ ] Refusal tests assert the target is unchanged, not just that an error was raised


### PR DESCRIPTION
## What changed

New language-agnostic skill `skills/common/destructive-operations/SKILL.md` (`guarding-destructive-operations`), registered as a standalone marketplace bundle and added to `python-library-complete` and `python-library-quality`. README skills table, install block, and bundle list updated; `metadata.version` bumped to 2.19.0.

## The pattern that motivated it

Two failure shapes kept showing up in unrelated codebases, in different languages, and they take the same fix:

- **Blast radius.** A `--rebuild`-style command recreates state by orphan-checkout plus a recursive delete of every tracked file. That is correct only in a dedicated single-purpose target and destroys everything else in a mixed one — and the loose fix (`startswith(".state")`) happily admits `.state-backup/`, so the guard passes on exactly the repository it was meant to refuse.
- **Boundary escape.** A public argument (a baseline name, a template id) is joined onto a base directory with an implicit suffix, and an absolute path or `..` segment reads any file on disk. The fix is two checks, not one: an identifier regex *and* `resolve()` + containment. Neutering only the containment half still passes every `..` test — only a symlink placed inside the directory catches it.

Both fixes also surfaced sub-lessons worth encoding: a guard is only "refuses safely" if it runs before the first statement with an effect (the in-memory state clear and the branch checkout both count); a guard on the destructive path is invisible to `--dry-run`, which is defensible but must be stated; a broad `except Exception` upstream can turn a hard refusal into an ordinary error-shaped result; and adding a precondition turns previously-loose test fixtures into the *rejected* shape, silently costing coverage of the destructive path unless they are tightened.

## How a reader benefits

Anyone writing or reviewing a `--rebuild`/`--reset`/`--purge` command, a bulk delete, a history rewrite, or code that turns an argument into a path gets a checklist that names the specific mistakes — string-prefix ownership checks, single-check path validation, guards placed after the first mutation, unrouted internal helpers — plus the fixture pairs (`base-backup/`, a symlink) and the per-half mutation tests that actually separate the correct implementation from the plausible wrong one.