### PR TITLE
Treat invalid scanner output as a failed security scan

### DIFF
--- a/skills/python/security-audit/scripts/security_scan.py
+++ b/skills/python/security-audit/scripts/security_scan.py
@@ -5,9 +5,9 @@ Runs Bandit (static analysis), pip-audit (dependency CVEs), Semgrep (pattern-bas
 SAST), and detect-secrets (hardcoded credentials), aggregates the findings, and
 exits non-zero when any blocking issue is found so it can gate CI.
 
-A scanner that could not run at all is a gate failure too: exit 1 on blocking
-findings, exit 2 when a requested scanner did not run, and 0 only when every
-requested scanner ran clean. Pass --allow-scanner-failure to tolerate scanners
+A scanner that could not run at all — or whose output could not be parsed — is a
+gate failure too: exit 1 on blocking findings, exit 2 when a requested scanner
+produced no usable result, and 0 only when every requested scanner ran clean. Pass --allow-scanner-failure to tolerate scanners
 that could not run.
 
 Usage:
@@ -28,6 +28,10 @@ SCAN_TIMEOUT = 300  # seconds
 
 # Cap per-tool findings printed to the console; the full set still goes to --output.
 MAX_FINDINGS_SHOWN = 10
+
+# Raised while reading a scanner's stdout that is not JSON, or is JSON in a
+# structure this script cannot walk.
+PARSE_ERRORS = (json.JSONDecodeError, AttributeError, TypeError)
 
 
 @dataclass
@@ -63,6 +67,17 @@ def _run(cmd: list[str], tool: str, install_hint: str, ok_returncodes=(0, 1)):
     return result.stdout, None
 
 
+def _unparseable(tool: str, reason: str) -> ScanResult:
+    """Record a scanner that ran but emitted output this script cannot consume.
+
+    The reason is the exception's own short message; the scanner's payload is
+    never embedded, so a truncated or diagnostic report stays readable.
+    """
+    return ScanResult(
+        tool, False, error=f"{tool} produced output that could not be parsed: {reason}"
+    )
+
+
 def run_bandit(project_path: Path) -> ScanResult:
     """Run Bandit static security analysis. Blocks on HIGH/CRITICAL findings."""
     target = project_path / "src"
@@ -77,11 +92,14 @@ def run_bandit(project_path: Path) -> ScanResult:
     if err:
         return err
 
-    data = json.loads(stdout) if stdout else {"results": []}
-    findings = data.get("results", [])
-    blocking = sum(
-        1 for f in findings if f.get("issue_severity", "").upper() in ("HIGH", "CRITICAL")
-    )
+    try:
+        data = json.loads(stdout) if stdout else {"results": []}
+        findings = data.get("results", [])
+        blocking = sum(
+            1 for f in findings if f.get("issue_severity", "").upper() in ("HIGH", "CRITICAL")
+        )
+    except PARSE_ERRORS as e:
+        return _unparseable("bandit", str(e))
     return ScanResult("bandit", True, findings, blocking)
 
 
@@ -95,10 +113,13 @@ def run_pip_audit(project_path: Path) -> ScanResult:
     if err:
         return err
 
-    data = json.loads(stdout) if stdout else []
-    # pip-audit returns either a bare list or {"dependencies": [...]} across versions.
-    deps = data.get("dependencies", []) if isinstance(data, dict) else data
-    findings = [d for d in deps if d.get("vulns")]
+    try:
+        data = json.loads(stdout) if stdout else []
+        # pip-audit returns either a bare list or {"dependencies": [...]} across versions.
+        deps = data.get("dependencies", []) if isinstance(data, dict) else data
+        findings = [d for d in deps if d.get("vulns")]
+    except PARSE_ERRORS as e:
+        return _unparseable("pip-audit", str(e))
     return ScanResult("pip-audit", True, findings, blocking=len(findings))
 
 
@@ -112,11 +133,14 @@ def run_semgrep(project_path: Path) -> ScanResult:
     if err:
         return err
 
-    data = json.loads(stdout) if stdout else {"results": []}
-    findings = data.get("results", [])
-    blocking = sum(
-        1 for f in findings if f.get("extra", {}).get("severity", "").upper() == "ERROR"
-    )
+    try:
+        data = json.loads(stdout) if stdout else {"results": []}
+        findings = data.get("results", [])
+        blocking = sum(
+            1 for f in findings if f.get("extra", {}).get("severity", "").upper() == "ERROR"
+        )
+    except PARSE_ERRORS as e:
+        return _unparseable("semgrep", str(e))
     return ScanResult("semgrep", True, findings, blocking)
 
 
@@ -130,12 +154,15 @@ def check_secrets(project_path: Path) -> ScanResult:
     if err:
         return err
 
-    data = json.loads(stdout) if stdout else {"results": {}}
-    findings = [
-        {"file": file_path, "type": secret.get("type"), "line": secret.get("line_number")}
-        for file_path, secrets in data.get("results", {}).items()
-        for secret in secrets
-    ]
+    try:
+        data = json.loads(stdout) if stdout else {"results": {}}
+        findings = [
+            {"file": file_path, "type": secret.get("type"), "line": secret.get("line_number")}
+            for file_path, secrets in data.get("results", {}).items()
+            for secret in secrets
+        ]
+    except PARSE_ERRORS as e:
+        return _unparseable("detect-secrets", str(e))
     return ScanResult("detect-secrets", True, findings, blocking=len(findings))
 
 

--- a/tests/test_security_scan.py
+++ b/tests/test_security_scan.py
@@ -53,6 +53,119 @@ class RunFailureTests(unittest.TestCase):
         self.assertIn("timed out", err.error)
 
 
+class ParseFailureTests(unittest.TestCase):
+    """A scanner whose output cannot be read is a failed scan, not a traceback."""
+
+    RUNNERS = (
+        ("run_bandit", "bandit"),
+        ("run_pip_audit", "pip-audit"),
+        ("run_semgrep", "semgrep"),
+        ("check_secrets", "detect-secrets"),
+    )
+
+    @staticmethod
+    @contextlib.contextmanager
+    def stdout(text):
+        with mock.patch.object(SECURITY_SCAN, "_run", lambda *a, **k: (text, None)):
+            yield
+
+    def test_malformed_json_is_an_unsuccessful_result(self):
+        for attr, tool in self.RUNNERS:
+            with self.subTest(runner=attr), self.stdout("not-json"):
+                scan = getattr(SECURITY_SCAN, attr)(Path("."))
+
+                self.assertFalse(scan.success)
+                self.assertEqual(scan.tool, tool)
+                self.assertEqual(scan.findings, [])
+                self.assertEqual(scan.blocking, 0)
+                self.assertIn(tool, scan.error)
+                self.assertIn("could not be parsed", scan.error)
+
+    def test_unusable_json_structure_is_an_unsuccessful_result(self):
+        # Well-formed JSON of the wrong shape, e.g. a diagnostic array.
+        for attr, tool in self.RUNNERS:
+            with self.subTest(runner=attr), self.stdout('["diagnostic", 1]'):
+                scan = getattr(SECURITY_SCAN, attr)(Path("."))
+
+                self.assertFalse(scan.success)
+                self.assertEqual(scan.tool, tool)
+                self.assertEqual(scan.blocking, 0)
+                self.assertIn("could not be parsed", scan.error)
+
+    def test_error_does_not_embed_the_scanner_payload(self):
+        payload = "x" * 10_000
+        for attr, _tool in self.RUNNERS:
+            with self.subTest(runner=attr), self.stdout(payload):
+                scan = getattr(SECURITY_SCAN, attr)(Path("."))
+
+                self.assertFalse(scan.success)
+                self.assertNotIn(payload, scan.error)
+                self.assertLess(len(scan.error), 200)
+
+    def test_valid_output_still_reports_its_findings(self):
+        cases = {
+            "run_bandit": (
+                json.dumps(
+                    {
+                        "results": [
+                            {"issue_text": "eval", "issue_severity": "HIGH"},
+                            {"issue_text": "assert", "issue_severity": "LOW"},
+                        ]
+                    }
+                ),
+                2,
+                1,
+            ),
+            "run_pip_audit": (
+                json.dumps(
+                    {
+                        "dependencies": [
+                            {"name": "requests", "version": "1.0", "vulns": [{"id": "PYSEC-1"}]},
+                            {"name": "attrs", "version": "23.1", "vulns": []},
+                        ]
+                    }
+                ),
+                1,
+                1,
+            ),
+            "run_semgrep": (
+                json.dumps(
+                    {
+                        "results": [
+                            {"check_id": "a", "extra": {"severity": "ERROR"}},
+                            {"check_id": "b", "extra": {"severity": "WARNING"}},
+                        ]
+                    }
+                ),
+                2,
+                1,
+            ),
+            "check_secrets": (
+                json.dumps(
+                    {"results": {"a.py": [{"type": "AWS Key", "line_number": 3}]}}
+                ),
+                1,
+                1,
+            ),
+        }
+        for attr, (payload, findings, blocking) in cases.items():
+            with self.subTest(runner=attr), self.stdout(payload):
+                scan = getattr(SECURITY_SCAN, attr)(Path("."))
+
+                self.assertTrue(scan.success, scan.error)
+                self.assertEqual(len(scan.findings), findings)
+                self.assertEqual(scan.blocking, blocking)
+
+    def test_empty_output_is_still_a_clean_scan(self):
+        for attr, _tool in self.RUNNERS:
+            with self.subTest(runner=attr), self.stdout(""):
+                scan = getattr(SECURITY_SCAN, attr)(Path("."))
+
+                self.assertTrue(scan.success, scan.error)
+                self.assertEqual(scan.findings, [])
+                self.assertEqual(scan.blocking, 0)
+
+
 class ReportTests(unittest.TestCase):
     """The console summary must not read as a clean audit when nothing ran."""
 
@@ -170,6 +283,38 @@ class ExitCodeTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         self.assertNotIn("did not run", output)
+
+    def run_main_over_scanner_output(self, stdout, *extra_args):
+        """Drive main() through the real runners with only the subprocess mocked."""
+        argv = ["security_scan.py", str(self.project), *extra_args]
+        out = io.StringIO()
+        original_argv = sys.argv
+        sys.argv = argv
+        try:
+            with (
+                mock.patch.object(SECURITY_SCAN, "_run", lambda *a, **k: (stdout, None)),
+                contextlib.redirect_stdout(out),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                SECURITY_SCAN.main()
+        finally:
+            sys.argv = original_argv
+        return raised.exception.code, out.getvalue()
+
+    def test_unparseable_output_reaches_the_report_and_exits_two(self):
+        code, output = self.run_main_over_scanner_output("not-json")
+
+        self.assertEqual(code, 2)
+        self.assertIn("Total findings: 0 (0 blocking)", output)
+        self.assertIn(
+            "Scanners that did not run: 4 (bandit, pip-audit, semgrep, detect-secrets)", output
+        )
+
+    def test_allow_scanner_failure_tolerates_unparseable_output(self):
+        code, output = self.run_main_over_scanner_output("not-json", "--allow-scanner-failure")
+
+        self.assertEqual(code, 0)
+        self.assertIn("did not run", output)
 
     def test_json_report_records_the_scanners_that_did_not_run(self):
         results = self.clean()


### PR DESCRIPTION
Closes #94

`security_scan.py` normalized scanner *launch* failures through `_run()`, but each runner then parsed accepted stdout with an unguarded `json.loads` and unchecked structure walks. A scanner that exits with an accepted status while emitting truncated or diagnostic output crashed the gate with a traceback instead of producing the combined report and the failed-scanner exit status.

## What changed

- `_unparseable(tool, reason)` builds a `ScanResult(success=False, ...)` naming the scanner and stating that its output could not be parsed. The reason is the exception's own short message — the scanner's payload is never embedded.
- Module constant `PARSE_ERRORS = (json.JSONDecodeError, AttributeError, TypeError)`; each of `run_bandit`, `run_pip_audit`, `run_semgrep`, and `check_secrets` wraps its existing extraction block in one `try` that returns `_unparseable(...)`.
- The module docstring's exit-status paragraph now says "produced no usable result" rather than "did not run", since a parse failure reuses that path.
- Command lines, severity policy, report schema, `--output` JSON fields, and successful-output behavior are unchanged. Parse failures flow through the existing `failed_scanners` path, so they already appear in `scanners_failed` / `scanner_failures` and in the "Scanners that did not run" line — no new field was added.

### One judgment call past the issue's literal wording

The issue's first criterion names malformed JSON, which a decode guard alone covers. But well-formed JSON of the wrong *shape* was also measured to crash: `'["diagnostic", 1]'` raised `AttributeError: 'list' object has no attribute 'get'` in three runners and `'int' object has no attribute 'get'` in `run_pip_audit`. Since there was a repro in hand, the guard catches the structure-walk errors too rather than shipping a known crash. That is why it is one `except` per runner rather than a decode-only helper.

## Tests

`tests/test_security_scan.py` gains `ParseFailureTests` (real runners, only `_run()` mocked) and two CLI cases in `ExitCodeTests` driven the same way:

- malformed JSON → `success is False`, correct `tool`, no findings, `blocking == 0`, error names the scanner and says "could not be parsed" — for all four runners;
- unusable JSON structure → same, for all four runners;
- a 10,000-character payload is absent from `error` and the message stays under 200 characters;
- valid fixtures still report exact findings and blocking counts per runner (2/1, 1/1, 2/1, 1/1);
- empty stdout is still a clean scan;
- a CLI run whose scanners all emit `not-json` reaches `format_report()` (`Total findings: 0 (0 blocking)`, `Scanners that did not run: 4 (bandit, pip-audit, semgrep, detect-secrets)`) and exits `2`; with `--allow-scanner-failure` it exits `0`.

## Verification

`uv run python -m unittest discover -s tests` — **42 tests, OK** (35 on `main`, also green at the branch point).

Mutation-checked both directions, with `__pycache__` cleared and `PYTHONDONTWRITEBYTECODE=1` set (the suite loads the script via `spec_from_file_location`):

| Mutation | Result |
|---|---|
| Revert to the unguarded parsing on `main` | **FAILED (errors=14)** — the original tracebacks, one per runner per case |
| Fail-open guard: `_unparseable` returns `ScanResult(tool, True, [], 0)` | **FAILED (failures=14)** |

The second mutation is the one that matters here: a guard that merely stops the traceback while reporting a clean audit would pass any "does not raise" test. Every parser test asserts `success is False` and the CLI test asserts exit `2`, so it goes red. Restoring the fix returned the suite to 42 green.

`uvx ruff check` on the two changed files reports the same 3 pre-existing findings as at the branch point (`EXE001`, `PLW1510`, `I001`) and nothing new.