### PR TITLE
Add CI plus version-math and explicit-version tests for bump_version.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      # The helper scripts need 3.11+ (tomllib) and 3.10+ (PEP 604 unions).
+      - name: Run the test suite with pytest
+        run: uv run --no-project --with 'pytest>=9' python -m pytest tests
+
+      # The repo's documented command, and the check that the suite still runs
+      # under plain stdlib unittest with nothing installed.
+      - name: Run the test suite with unittest
+        run: uv run --no-project python -m unittest discover -s tests

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -55,6 +55,39 @@ version = "8.8.8"
 """
 
 
+class VersionMathTests(unittest.TestCase):
+    """parse_version and bump_version are the pure core of the script."""
+
+    def test_parse_version_splits_a_three_part_version(self):
+        self.assertEqual(BUMP_VERSION.parse_version("1.2.3"), (1, 2, 3))
+        self.assertEqual(BUMP_VERSION.parse_version("10.0.07"), (10, 0, 7))
+
+    def test_parse_version_rejects_anything_else(self):
+        for version in ("1.2", "1.2.3.4", "1.2.x", "v1.2.3", "1.2.-3", "1.2.3 ", "", "1.2.²"):
+            with self.subTest(version=version), self.assertRaises(ValueError):
+                BUMP_VERSION.parse_version(version)
+
+    def test_bump_types_move_the_expected_component(self):
+        cases = [
+            ("1.2.3", "major", "2.0.0"),
+            ("1.2.3", "minor", "1.3.0"),
+            ("1.2.3", "patch", "1.2.4"),
+            ("0.9.9", "minor", "0.10.0"),
+            ("1.9.0", "major", "2.0.0"),
+        ]
+        for current, spec, expected in cases:
+            with self.subTest(current=current, spec=spec):
+                self.assertEqual(BUMP_VERSION.bump_version(current, spec), expected)
+
+    def test_explicit_version_is_used_verbatim(self):
+        self.assertEqual(BUMP_VERSION.bump_version("1.2.3", "1.5.0"), "1.5.0")
+        self.assertEqual(BUMP_VERSION.bump_version("1.2.3", "0.1.0"), "0.1.0")
+
+    def test_explicit_version_must_be_well_formed(self):
+        with self.assertRaises(ValueError):
+            BUMP_VERSION.bump_version("1.2.3", "1.5")
+
+
 class ProjectVersionTests(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -229,6 +262,54 @@ class ChangelogReportingTests(unittest.TestCase):
         self.assertIn("Warning", output)
         self.assertIn("## [Unreleased]", output)
         self.assertEqual(self.changelog.read_bytes(), before)
+
+
+class ExplicitVersionCommandTests(unittest.TestCase):
+    """`bump_version.py X.Y.Z` must set that version, not only major/minor/patch."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        # main() resolves --project, so match that here (/var -> /private/var).
+        self.project = Path(self.temp_dir.name).resolve()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.pyproject = self.project / "pyproject.toml"
+        self.pyproject.write_text(PYPROJECT)
+
+    def run_main(self, *args):
+        argv = ["bump_version.py", *args, "--project", str(self.project)]
+        out = io.StringIO()
+        original_argv = sys.argv
+        sys.argv = argv
+        try:
+            with contextlib.redirect_stdout(out):
+                BUMP_VERSION.main()
+        finally:
+            sys.argv = original_argv
+        return out.getvalue()
+
+    def test_positional_version_sets_that_exact_version(self):
+        output = self.run_main("1.5.0")
+
+        self.assertIn("Version: 1.2.3 -> 1.5.0", output)
+        self.assertIn('version = "1.5.0"', self.pyproject.read_text())
+        self.assertEqual(BUMP_VERSION.get_current_version(self.project), "1.5.0")
+
+    def test_positional_version_flag_form_agrees(self):
+        self.run_main("--version", "1.5.0")
+
+        self.assertEqual(BUMP_VERSION.get_current_version(self.project), "1.5.0")
+
+    def test_positional_bump_type_still_works(self):
+        self.run_main("minor")
+
+        self.assertEqual(BUMP_VERSION.get_current_version(self.project), "1.3.0")
+
+    def test_lower_positional_version_is_refused_without_allow_downgrade(self):
+        with self.assertRaises(SystemExit) as raised:
+            self.run_main("1.0.0")
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertEqual(BUMP_VERSION.get_current_version(self.project), "1.2.3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4

## What changed

- `.github/workflows/ci.yml` — new. Runs the suite on pull requests and on pushes to `main`,
  on `ubuntu-latest`, under Python 3.12 (`bump_version.py` needs 3.11+ for `tomllib`).
  Two steps: `python -m pytest tests` with pytest installed via `uv run --with`, and the
  repo's own documented `python -m unittest discover -s tests`.
- `tests/test_bump_version.py` — two new classes, +81 lines:
  - `VersionMathTests` covers `parse_version` (three-part parse, and rejection of
    2-part, 4-part, non-numeric, `v`-prefixed, negative, trailing-space, empty, and
    superscript-digit inputs) and `bump_version` major/minor/patch math plus the
    explicit-version branch.
  - `ExplicitVersionCommandTests` drives `main()` against a tmp-dir project and asserts
    that `bump_version.py 1.5.0` writes `version = "1.5.0"` into `pyproject.toml` — the
    explicit-positional path, which guards the fix from #3. It also pins the `--version`
    flag form, a `minor` bump, and the downgrade refusal.

Suite goes 35 -> 44 tests. No skill content, script behaviour, README, or manifest changes.

## Two notes on scope

**The issue's premise was partly stale.** It says the repo has zero tests; `tests/` already
held 35 tests across four `unittest` modules covering all three helper scripts and the
marketplace catalog. So this PR adds only the coverage the issue names as missing rather
than a new suite. In particular, acceptance item 2's tmp-dir `update_version` round-trip
was already covered by `ProjectVersionTests.test_update_changes_only_project_version`
(it asserts the whole `pyproject.toml` text after the write, and that only the `[project]`
table moved), so I did not add a near-duplicate.

**Tests stay stdlib `unittest`; CI runs them through pytest.** pytest collects
`unittest.TestCase` classes directly, so acceptance item 1 is met without restyling 615
lines of existing tests or introducing a `pyproject.toml` to a repo that deliberately has
none. The workflow keeps the plain `unittest` step too, so the suite is still guaranteed to
run with nothing installed.

Trigger shape (`push: branches: [main]` + unfiltered `pull_request`, plus a `concurrency`
block) follows this repo's own `running-github-actions-efficiently` skill, which calls out
unfiltered `push` + `pull_request` as double-firing.

## Verification

All commands run from the repo root on macOS.

Baseline at the branch point (`901c275`), before any change:

    $ uv run --no-project python -m unittest discover -s tests
    Ran 35 tests in 0.061s
    OK

After the change, both CI steps exactly as the workflow runs them:

    $ uv run --no-project --with 'pytest>=9' python -m pytest tests
    44 passed in 0.10s                                    # exit 0

    $ uv run --no-project python -m unittest discover -s tests
    Ran 44 tests in 0.058s
    OK                                                    # exit 0

**pytest reports `subTest` failures.** `tests/test_marketplace_catalog.py` and
`tests/test_security_scan.py` are subTest-heavy, and pytest has historically needed the
`pytest-subtests` plugin to surface those. Checked rather than assumed: with one skill path
in `marketplace.json` renamed to a nonexistent directory, pytest 9.1.1 printed
`SUBFAILED(skill_path=...)` alongside the ordinary failure and exited 1. So the pytest step
is not weaker than the unittest one, and no plugin is needed. The workflow pins `pytest>=9`
for that reason. Manifest restored from a backup afterwards; `git status` clean.

**Mutation-tested — the new tests are not vacuous.** Tests committed first, `__pycache__`
cleared between runs, each mutation confirmed live by reading it back through the
interpreter before trusting the result, and the baseline re-run green after each restore:

| Mutation to `bump_version.py` | Result |
|---|---|
| `minor` returns `f"{major}.{minor + 1}.{patch}"` (patch not reset) | 3 failures |
| explicit-version branch returns `current` instead of `spec` (reinstates the #3 class of bug) | 4 failures |
| `parse_version` drops the `len(parts) != 3` guard | 1 failure, 2 errors |

The second row is the one that carries acceptance item 3 — it is caught by both the unit
test on `bump_version` and the `main()`-level test that reads the version back out of the
written `pyproject.toml`. The first mutation attempt at that row silently did not apply
(a `perl -pe` pattern that matched nothing) and the suite reported OK; the table above is
from the re-run where `bump_version('1.2.3', '1.5.0')` was confirmed to return `1.2.3`.

**Lint.** No lint gate is added — `ruff` with its default rule set already reports findings
on `main` in files this PR does not touch. I did check that the diff adds none of its own:
`uvx ruff check tests/test_bump_version.py` reports the same single pre-existing `I001`
before and after (an initial `SIM117` from a nested `with` in a `subTest` loop was fixed).

CI itself has never run in this repo before, so this PR's own check run is the first
real execution of the workflow.